### PR TITLE
fix: create volume for self-hosted runner avoid file driver error

### DIFF
--- a/self-hosted-runner/compose.yml
+++ b/self-hosted-runner/compose.yml
@@ -15,3 +15,8 @@ services:
       args:
         GH_RUNNER_VERSION: 2.329.0
         TARGET_ARCH: x64
+    volumes:
+      - fa-self:/var/lib/docker
+
+volumes:
+  fa-self:


### PR DESCRIPTION
This pull request updates the Docker Compose configuration for the self-hosted runner by adding a named volume. This change helps to persist data in `/var/lib/docker` across container restarts.

Configuration improvements:

* Added a named volume, `fa-self`, to the `services` section and mapped it to `/var/lib/docker` in the container.
* Defined the `fa-self` volume in the `volumes` section to enable persistent storage.


https://github.com/docker/cli/issues/6646