### PR TITLE
feat: Add ARM64 support with QEMU in self-hosted runner

### DIFF
--- a/.github/workflows/_build_linux_self_host.yml
+++ b/.github/workflows/_build_linux_self_host.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: boolean
         default: true
+      container-image:
+        description: "Container image"
+        required: false
+        type: string
+        default: "ubuntu:22.04"
 
 jobs:
   build_wheels_self_hosted:
@@ -45,7 +50,7 @@ jobs:
     name: Build wheels and Upload (Linux x86_64, self-hosted runner)
     runs-on: ${{ inputs.runner }}
     container:
-      image: ubuntu:22.04
+      image: ${{ inputs.container-image }}
     defaults:
       run:
         shell: bash
@@ -53,6 +58,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       TERM: xterm-256color
     timeout-minutes: 2160
+
     steps:
       - name: Install tools
         shell: bash

--- a/.github/workflows/test-arm-self-hosted.yml
+++ b/.github/workflows/test-arm-self-hosted.yml
@@ -1,0 +1,30 @@
+name: Test ARM Linux build (self-hosted)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # #########################################################
+  # Build wheels with self-hosted runner
+  # #########################################################
+  build_wheels_self_hosted:
+    name: Build wheels and Upload (Linux ARM64, self-hosted runner)
+    uses: ./.github/workflows/_build_linux_self_host.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        flash-attn-version: ["2.8.3"]
+        python-version: ["3.13"]
+        torch-version: ["2.9.1"]
+        # https://developer.nvidia.com/cuda-toolkit-archive
+        cuda-version: ["13.0.1"]
+        runner: ["self-hosted"]
+    with:
+      flash-attn-version: ${{ matrix.flash-attn-version }}
+      python-version: ${{ matrix.python-version }}
+      torch-version: ${{ matrix.torch-version }}
+      cuda-version: ${{ matrix.cuda-version }}
+      is-upload: false
+      runner: ${{ matrix.runner}}
+      use-container: true
+      container-image: "arm64v8/ubuntu:22.04"

--- a/self-hosted-runner/Dockerfile
+++ b/self-hosted-runner/Dockerfile
@@ -37,6 +37,7 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     containerd.io \
     docker-buildx-plugin \
     docker-compose-plugin \
+    qemu-user-static \
     && rm -rf /var/lib/apt/lists/*
 
 # Install dotnet


### PR DESCRIPTION
- Add container-image input parameter to _build_linux_self_host workflow
- Create test-arm-self-hosted workflow for ARM64 Linux builds
- Add qemu-user-static package to self-hosted runner Dockerfile
- Enable ARM64 container builds using arm64v8/ubuntu:22.04