### PR TITLE
feat: add manylinux self-hosted build job and enable version matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
   # #########################################################
   # Linux
   # #########################################################
+
+  # ################ GitHub-hosted runner ################
   build_wheels_linux:
     name: Build Linux x86_64
     needs: [create_releases, create_matrix]
@@ -76,6 +78,7 @@ jobs:
       runner: "ubuntu-22.04-arm"
     secrets: inherit
 
+  # ################ Self-hosted runner ################
   build_wheels_linux_self_hosted:
     name: Build Linux (self-hosted)
     needs: [create_releases, create_matrix]
@@ -116,6 +119,27 @@ jobs:
       torch-version: ${{ matrix.torch-version }}
       cuda-version: ${{ matrix.cuda-version }}
       runner: '["self-hosted-arm", "arm64"]'
+    secrets: inherit
+
+  build_wheels_manylinux_self_hosted:
+    name: Build manylinux (self-hosted)
+    needs: [create_releases, create_matrix]
+    if: ${{ fromjson(needs.create_matrix.outputs.matrix).manylinux_self_hosted }}
+    strategy:
+      fail-fast: false
+      matrix:
+        flash-attn-version: ${{ fromjson(needs.create_matrix.outputs.matrix).manylinux_self_hosted.flash-attn-version }}
+        python-version: ${{ fromjson(needs.create_matrix.outputs.matrix).manylinux_self_hosted.python-version }}
+        torch-version: ${{ fromjson(needs.create_matrix.outputs.matrix).manylinux_self_hosted.torch-version }}
+        cuda-version: ${{ fromjson(needs.create_matrix.outputs.matrix).manylinux_self_hosted.cuda-version }}
+        exclude: ${{ fromjson(needs.create_matrix.outputs.matrix).exclude }}
+    uses: ./.github/workflows/_build_manylinux_self_host.yml
+    with:
+      flash-attn-version: ${{ matrix.flash-attn-version }}
+      python-version: ${{ matrix.python-version }}
+      torch-version: ${{ matrix.torch-version }}
+      cuda-version: ${{ matrix.cuda-version }}
+      runner: '["self-hosted", "x64"]'
     secrets: inherit
 
   # #########################################################
@@ -168,6 +192,7 @@ jobs:
       - build_wheels_linux_arm64
       - build_wheels_linux_self_hosted
       - build_wheels_linux_arm64_self_hosted
+      - build_wheels_manylinux_self_hosted
       - build_wheels_windows
       - build_wheels_windows_code_build
     if: always()
@@ -197,6 +222,7 @@ jobs:
       - build_wheels_linux_arm64
       - build_wheels_linux_self_hosted
       - build_wheels_linux_arm64_self_hosted
+      - build_wheels_manylinux_self_hosted
       - build_wheels_windows
       - build_wheels_windows_code_build
     permissions:

--- a/create_matrix.py
+++ b/create_matrix.py
@@ -91,19 +91,19 @@ LINUX_ARM64_MATRIX = {
 LINUX_SELF_HOSTED_MATRIX = {
     "flash-attn-version": [
         "2.6.3",
-        # "2.7.4",
-        # "2.8.3",
+        "2.7.4",
+        "2.8.3",
     ],
     "python-version": [
-        # "3.10",
-        # "3.11",
-        # "3.12",
+        "3.10",
+        "3.11",
+        "3.12",
         # "3.13",
-        "3.14",
+        # "3.14",
     ],
     "torch-version": ["2.9.1"],
     "cuda-version": [
-        # "12.8",
+        "12.8",
         "13.0",
     ],
 }
@@ -200,11 +200,14 @@ def main():
                 "linux_self_hosted": False,
                 # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
                 #
+                # "manylinux_self_hosted": False,
+                "manylinux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
+                #
                 "linux_arm64_self_hosted": False,
                 # "linux_arm64_self_hosted": LINUX_ARM64_SELF_HOSTED_MATRIX,
                 #
-                # "windows": False,
-                "windows": WINDOWS_MATRIX,
+                "windows": False,
+                # "windows": WINDOWS_MATRIX,
                 #
                 "windows_code_build": False,
                 # "windows_code_build": WINDOWS_CODEBUILD_MATRIX,


### PR DESCRIPTION
## Overview

Add manylinux self-hosted build job to the CI/CD workflow and enable the version matrix configuration for manylinux builds.

## Changes

- Add `build_wheels_manylinux_self_hosted` job to `.github/workflows/build.yml`
- Configure manylinux matrix with flash-attn versions: 2.6.3, 2.7.4, 2.8.3
- Enable Python versions: 3.10, 3.11, 3.12 for manylinux builds
- Configure CUDA versions: 12.8, 13.0 for manylinux builds
- Add manylinux_self_hosted to build and release workflow job dependencies
- Update `create_matrix.py` to enable manylinux_self_hosted matrix configuration
- Add section comments to organize GitHub-hosted and self-hosted runner jobs
- Disable Windows and Windows CodeBuild matrices temporarily

## Test Instructions

1. Verify the workflow file is syntactically correct:
   - Check that all job references in `build` and `release` jobs include `build_wheels_manylinux_self_hosted`
   
2. Verify the matrix configuration:
   - Confirm that manylinux builds will use the specified versions of flash-attn, Python, torch, and CUDA
   - Validate that the excluded matrix combinations are respected

3. Review the workflow trigger:
   - Ensure the manylinux job is properly conditional based on the matrix output