### PR TITLE
ci: add CUDA 12.9 and 13.1 support to build matrix

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -4,8 +4,12 @@ EXCLUDE = [
     # torch < 2.2 does not support Python 3.12
     {"python-version": "3.12", "torch-version": "2.0.1"},
     {"python-version": "3.12", "torch-version": "2.1.2"},
-    # TODO: Temporary exclusion - already built in v0.7.6
+    # TODO: Temporary exclusion - already built
     {"python-version": "3.12", "torch-version": "2.9.1", "cuda-version": "12.8"},
+    {"python-version": "3.10", "torch-version": "2.7.1", "cuda-version": "12.8"},
+    {"python-version": "3.13", "torch-version": "2.7.1", "cuda-version": "12.8"},
+    {"python-version": "3.10", "torch-version": "2.8.0", "cuda-version": "12.8"},
+    {"python-version": "3.11", "torch-version": "2.5.1", "cuda-version": "12.8"},
     # torch 2.0.1 does not support CUDA 12.x
     {"torch-version": "2.0.1", "cuda-version": "12.1"},
     {"torch-version": "2.0.1", "cuda-version": "12.4"},
@@ -55,7 +59,7 @@ LINUX_MATRIX = {
         "2.7.1",
         "2.8.0",
         "2.9.1",
-        "2.10.0",
+        # "2.10.0",
     ],
     "cuda-version": [
         "12.4",
@@ -84,7 +88,7 @@ LINUX_ARM64_MATRIX = {
         "2.7.1",
         # "2.8.0",
         "2.9.1",
-        "2.10.0",
+        # "2.10.0",
     ],
     "cuda-version": [
         "12.4",
@@ -106,22 +110,23 @@ LINUX_SELF_HOSTED_MATRIX = {
         "3.11",
         "3.12",
         "3.13",
-        # "3.14",
+        "3.14",
     ],
     "torch-version": [
-        "2.5.1",
-        "2.6.0",
-        "2.7.1",
+        # "2.5.1",
+        # "2.6.0",
+        # "2.7.1",
         "2.8.0",
-        # "2.9.1",
-        "2.10.0",
+        "2.9.1",
+        # "2.10.0",
     ],
     "cuda-version": [
-        "12.4",
-        "12.6",
-        "12.8",
+        # "12.4",
+        # "12.6",
+        # "12.8",
         "12.9",
-        "13.0",
+        # "13.0",
+        "13.1",
     ],
 }
 
@@ -144,7 +149,7 @@ LINUX_ARM64_SELF_HOSTED_MATRIX = {
         # "2.7.1",
         # "2.8.0",
         "2.9.1",
-        "2.10.0",
+        # "2.10.0",
     ],
     "cuda-version": [
         # "12.4",
@@ -173,7 +178,7 @@ WINDOWS_MATRIX = {
         # "2.7.1",
         # "2.8.0",
         "2.9.1",
-        "2.10.0",
+        # "2.10.0",
     ],
     "cuda-version": [
         # "12.4",
@@ -198,7 +203,7 @@ WINDOWS_CODEBUILD_MATRIX = {
     ],
     "torch-version": [
         "2.9.1",
-        "2.10.0",
+        # "2.10.0",
     ],
     "cuda-version": [
         "12.8",
@@ -224,7 +229,7 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         "2.7.1",
         "2.8.0",
         "2.9.1",
-        "2.10.0",
+        # "2.10.0",
     ],
     "cuda-version": [
         # "12.4",
@@ -246,8 +251,8 @@ def main():
                 "linux_arm64": False,
                 # "linux_arm64": LINUX_ARM64_MATRIX,
                 #
-                "linux_self_hosted": False,
-                # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
+                # "linux_self_hosted": False,
+                "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
                 #
                 "linux_arm64_self_hosted": False,
                 # "linux_arm64_self_hosted": LINUX_ARM64_SELF_HOSTED_MATRIX,


### PR DESCRIPTION
## Overview and Background

Add support for CUDA 12.9 and 13.1 in the build matrix configuration. This update also includes Python 3.14 support for Linux self-hosted runners and several build matrix adjustments.

## Related Issues

Closes #73

## Changes

- Add CUDA 12.9 and 13.1 support to Linux self-hosted matrix
- Add Python 3.14 support for Linux self-hosted runners
- Add several version exclusions for specific Torch and CUDA combinations that have already been built
- Temporarily disable Torch 2.10.0 in all build matrices
- Enable Linux self-hosted runner builds in the main configuration

## Test Instructions

- Verify the CI workflow runs successfully with the new matrix configurations
- Check that the generated build matrix includes the expected CUDA 12.9 and 13.1 combinations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces newer CUDA/Python targets and enables self-hosted Linux builds.
> 
> - Enables `linux_self_hosted` builds in `main()` using `LINUX_SELF_HOSTED_MATRIX`
> - Updates `LINUX_SELF_HOSTED_MATRIX`: adds CUDA `12.9` and `13.1`, enables Python `3.14`, and narrows Torch to `2.8.0`/`2.9.1`
> - Disables Torch `2.10.0` across all matrices by commenting it out
> - Adds temporary exclusions and compatibility guards for specific Python/Torch/CUDA combinations (incl. several CUDA `12.8` cases)
> - Keeps other platforms in `main()` disabled; `windows_self_hosted` remains enabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0694ee874e963b8411c0eaa8aeba17b74b726a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->