### PR TITLE
ci: add git pull before updating docs in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,6 +253,7 @@ jobs:
 
       - name: Update docs
         run: |
+          git pull
           gh release view "${{ github.ref_name }}" --json assets > /tmp/assets.json
           python create_release_history.py \
             --assets /tmp/assets.json \


### PR DESCRIPTION
- Add git pull to 'Update docs' step in build.yml to prevent potential merge conflicts during CI runs.