### PR TITLE
feat: add Linux no-container build workflow for self-hosted runners

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -45,6 +45,58 @@ runs:
         current_dir=$(pwd)
         echo "$current_dir/.venv/bin" >> $GITHUB_PATH
 
+    - name: Debug Python include paths
+      shell: bash
+      run: |
+        echo "===== Python binary info ====="
+        which python
+        python --version
+        REAL_PYTHON=$(readlink -f $(which python))
+        echo "Real python binary: $REAL_PYTHON"
+
+        echo ""
+        echo "===== sysconfig paths ====="
+        python -c "
+        import sysconfig
+        print('include:', sysconfig.get_path('include'))
+        print('platinclude:', sysconfig.get_path('platinclude'))
+        print('prefix:', sysconfig.get_config_var('prefix'))
+        print('INCLUDEPY:', sysconfig.get_config_var('INCLUDEPY'))
+        print('installed_base:', sysconfig.get_config_var('installed_base'))
+        "
+
+        echo ""
+        echo "===== Check if Python.h exists at sysconfig path ====="
+        INCLUDE_PATH=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")
+        echo "sysconfig include path: $INCLUDE_PATH"
+        if [ -f "$INCLUDE_PATH/Python.h" ]; then
+          echo "OK: Python.h found at $INCLUDE_PATH/Python.h"
+        else
+          echo "NOT FOUND: Python.h not at $INCLUDE_PATH/Python.h"
+        fi
+
+        echo ""
+        echo "===== .venv/include contents ====="
+        ls -la .venv/include/ 2>/dev/null || echo ".venv/include/ does not exist"
+        ls -la .venv/include/*/ 2>/dev/null || echo "No subdirectories in .venv/include/"
+
+        echo ""
+        echo "===== uv python directory ====="
+        UV_PYTHON_DIR="${HOME}/.local/share/uv/python"
+        echo "UV_PYTHON_DIR: $UV_PYTHON_DIR"
+        ls -la "$UV_PYTHON_DIR/" 2>/dev/null || echo "uv python dir not found"
+
+        echo ""
+        echo "===== Search for Python.h ====="
+        # Search in uv managed directory
+        find "$UV_PYTHON_DIR" -name "Python.h" 2>/dev/null | head -5 || echo "Not found in uv dir"
+        # Search in venv
+        find .venv -name "Python.h" 2>/dev/null | head -5 || echo "Not found in .venv"
+        # Search in real python prefix
+        REAL_PREFIX=$(dirname $(dirname "$REAL_PYTHON"))
+        echo "Real python prefix: $REAL_PREFIX"
+        find "$REAL_PREFIX" -name "Python.h" 2>/dev/null | head -5 || echo "Not found in real prefix"
+
     - name: Setup CUDA
       uses: mjun0812/setup-cuda@v1
       with:

--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -40,62 +40,10 @@ runs:
     - name: Install Python
       shell: bash
       run: |
-        uv venv -p ${{ inputs.python-version }}
+        uv venv -p ${{ inputs.python-version }} --python-preference only-managed
         uv pip install -U pip setuptools==75.8.0 wheel packaging psutil auditwheel
         current_dir=$(pwd)
         echo "$current_dir/.venv/bin" >> $GITHUB_PATH
-
-    - name: Debug Python include paths
-      shell: bash
-      run: |
-        echo "===== Python binary info ====="
-        which python
-        python --version
-        REAL_PYTHON=$(readlink -f $(which python))
-        echo "Real python binary: $REAL_PYTHON"
-
-        echo ""
-        echo "===== sysconfig paths ====="
-        python -c "
-        import sysconfig
-        print('include:', sysconfig.get_path('include'))
-        print('platinclude:', sysconfig.get_path('platinclude'))
-        print('prefix:', sysconfig.get_config_var('prefix'))
-        print('INCLUDEPY:', sysconfig.get_config_var('INCLUDEPY'))
-        print('installed_base:', sysconfig.get_config_var('installed_base'))
-        "
-
-        echo ""
-        echo "===== Check if Python.h exists at sysconfig path ====="
-        INCLUDE_PATH=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")
-        echo "sysconfig include path: $INCLUDE_PATH"
-        if [ -f "$INCLUDE_PATH/Python.h" ]; then
-          echo "OK: Python.h found at $INCLUDE_PATH/Python.h"
-        else
-          echo "NOT FOUND: Python.h not at $INCLUDE_PATH/Python.h"
-        fi
-
-        echo ""
-        echo "===== .venv/include contents ====="
-        ls -la .venv/include/ 2>/dev/null || echo ".venv/include/ does not exist"
-        ls -la .venv/include/*/ 2>/dev/null || echo "No subdirectories in .venv/include/"
-
-        echo ""
-        echo "===== uv python directory ====="
-        UV_PYTHON_DIR="${HOME}/.local/share/uv/python"
-        echo "UV_PYTHON_DIR: $UV_PYTHON_DIR"
-        ls -la "$UV_PYTHON_DIR/" 2>/dev/null || echo "uv python dir not found"
-
-        echo ""
-        echo "===== Search for Python.h ====="
-        # Search in uv managed directory
-        find "$UV_PYTHON_DIR" -name "Python.h" 2>/dev/null | head -5 || echo "Not found in uv dir"
-        # Search in venv
-        find .venv -name "Python.h" 2>/dev/null | head -5 || echo "Not found in .venv"
-        # Search in real python prefix
-        REAL_PREFIX=$(dirname $(dirname "$REAL_PYTHON"))
-        echo "Real python prefix: $REAL_PREFIX"
-        find "$REAL_PREFIX" -name "Python.h" 2>/dev/null | head -5 || echo "Not found in real prefix"
 
     - name: Setup CUDA
       uses: mjun0812/setup-cuda@v1

--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -46,7 +46,7 @@ runs:
         echo "$current_dir/.venv/bin" >> $GITHUB_PATH
 
     - name: Setup CUDA
-      uses: mjun0812/setup-cuda@v1
+      uses: mjun0812/setup-cuda@v1.3.0
       with:
         version: ${{ inputs.cuda-version }}
 

--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -51,11 +51,15 @@ runs:
         version: ${{ inputs.cuda-version }}
 
     - name: Build wheels
-      id: build_wheels
       shell: bash
       run: |
         chmod +x build_linux.sh
         ./build_linux.sh ${{ inputs.flash-attn-version }} ${{ inputs.python-version }} ${{ inputs.torch-version }} ${{ inputs.cuda-version }}
+
+    - name: Locate wheel
+      id: build_wheels
+      shell: bash
+      run: |
         if [[ "${{ inputs.flash-attn-version }}" == fa3:* ]]; then
           wheel_path=$(ls flash-attention/hopper/dist/*.whl | head -n 1)
           echo "IS_FA3=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -42,7 +42,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       TERM: xterm-256color
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Maximize build space
         run: |

--- a/.github/workflows/_build_linux_arm_self_host.yml
+++ b/.github/workflows/_build_linux_arm_self_host.yml
@@ -142,7 +142,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure Git safe directory
         shell: bash

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -77,61 +77,10 @@ jobs:
 
       - name: Install Python
         run: |
-          uv venv -p ${{ inputs.python-version }}
+          uv venv -p ${{ inputs.python-version }} --python-preference only-managed
           uv pip install -U pip setuptools==75.8.0 wheel packaging psutil auditwheel
           current_dir=$(pwd)
           echo "$current_dir/.venv/bin" >> $GITHUB_PATH
-
-      - name: Debug Python include paths
-        run: |
-          echo "===== Python binary info ====="
-          which python
-          python --version
-          REAL_PYTHON=$(readlink -f $(which python))
-          echo "Real python binary: $REAL_PYTHON"
-
-          echo ""
-          echo "===== sysconfig paths ====="
-          python -c "
-          import sysconfig
-          print('include:', sysconfig.get_path('include'))
-          print('platinclude:', sysconfig.get_path('platinclude'))
-          print('prefix:', sysconfig.get_config_var('prefix'))
-          print('INCLUDEPY:', sysconfig.get_config_var('INCLUDEPY'))
-          print('installed_base:', sysconfig.get_config_var('installed_base'))
-          "
-
-          echo ""
-          echo "===== Check if Python.h exists at sysconfig path ====="
-          INCLUDE_PATH=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")
-          echo "sysconfig include path: $INCLUDE_PATH"
-          if [ -f "$INCLUDE_PATH/Python.h" ]; then
-            echo "OK: Python.h found at $INCLUDE_PATH/Python.h"
-          else
-            echo "NOT FOUND: Python.h not at $INCLUDE_PATH/Python.h"
-          fi
-
-          echo ""
-          echo "===== .venv/include contents ====="
-          ls -la .venv/include/ 2>/dev/null || echo ".venv/include/ does not exist"
-          ls -la .venv/include/*/ 2>/dev/null || echo "No subdirectories in .venv/include/"
-
-          echo ""
-          echo "===== uv python directory ====="
-          UV_PYTHON_DIR="${HOME}/.local/share/uv/python"
-          echo "UV_PYTHON_DIR: $UV_PYTHON_DIR"
-          ls -la "$UV_PYTHON_DIR/" 2>/dev/null || echo "uv python dir not found"
-
-          echo ""
-          echo "===== Search for Python.h ====="
-          # Search in uv managed directory
-          find "$UV_PYTHON_DIR" -name "Python.h" 2>/dev/null | head -5 || echo "Not found in uv dir"
-          # Search in venv
-          find .venv -name "Python.h" 2>/dev/null | head -5 || echo "Not found in .venv"
-          # Search in real python prefix
-          REAL_PREFIX=$(dirname $(dirname "$REAL_PYTHON"))
-          echo "Real python prefix: $REAL_PREFIX"
-          find "$REAL_PREFIX" -name "Python.h" 2>/dev/null | head -5 || echo "Not found in real prefix"
 
       - name: Setup CUDA
         uses: mjun0812/setup-cuda@v1

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -174,10 +174,16 @@ jobs:
           echo "$current_dir/.venv/bin" >> $GITHUB_PATH
 
           # Export Python include path for C extensions (Python.h)
-          # uv's standalone Python stores headers under the managed Python,
-          # not under /usr/include, so we need to add it to CPATH.
-          # Use .venv/bin/python directly since GITHUB_PATH is not yet active in this step.
-          PYTHON_INCLUDE=$($current_dir/.venv/bin/python -c "import sysconfig; print(sysconfig.get_path('include'))")
+          # uv's standalone Python may report a wrong sysconfig include path
+          # (e.g. /usr/include/python3.12 which doesn't exist). Resolve the
+          # real Python binary and find the include directory relative to it.
+          REAL_PYTHON=$(readlink -f $current_dir/.venv/bin/python)
+          PYTHON_PREFIX=$(dirname $(dirname "$REAL_PYTHON"))
+          PYTHON_INCLUDE=$(find "$PYTHON_PREFIX/include" -name "Python.h" -printf "%h" -quit 2>/dev/null || echo "")
+          if [ -z "$PYTHON_INCLUDE" ]; then
+            # Fallback to sysconfig
+            PYTHON_INCLUDE=$($current_dir/.venv/bin/python -c "import sysconfig; print(sysconfig.get_path('include'))")
+          fi
           echo "Python include path: $PYTHON_INCLUDE"
           echo "CPATH=$PYTHON_INCLUDE${CPATH:+:$CPATH}" >> $GITHUB_ENV
 

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -66,98 +66,7 @@ jobs:
           echo "-----------------------------"
           free -h || true
 
-      - name: Install tools
-        run: |
-          # Check if key build tools are already installed
-          REQUIRED_CMDS=(gcc g++ clang ninja patchelf)
-          MISSING=false
-          for cmd in "${REQUIRED_CMDS[@]}"; do
-            if ! command -v "$cmd" >/dev/null 2>&1; then
-              echo "Missing: $cmd"
-              MISSING=true
-            fi
-          done
-
-          if [ "$MISSING" = "false" ]; then
-            echo "All build tools already installed, skipping"
-          else
-            echo "Installing build tools..."
-            # Auto-detect package manager and install dependencies
-            if command -v apt-get >/dev/null 2>&1; then
-              sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-                curl \
-                ca-certificates \
-                sudo \
-                software-properties-common \
-                wget \
-                unzip \
-                zip \
-                git \
-                build-essential \
-                gcc \
-                g++ \
-                clang \
-                ninja-build \
-                keyboard-configuration \
-                time \
-                patchelf
-            elif command -v dnf >/dev/null 2>&1; then
-              sudo dnf install -y \
-                curl \
-                ca-certificates \
-                sudo \
-                wget \
-                unzip \
-                zip \
-                git \
-                gcc-toolset-13-gcc \
-                gcc-toolset-13-gcc-c++ \
-                clang \
-                ninja-build \
-                time \
-                patchelf
-            else
-              echo "Error: No supported package manager found (apt-get or dnf)"
-              exit 1
-            fi
-          fi
-
-          # Activate gcc-toolset-13 for CUDA compatibility (always check, even if skipped install)
-          if [ -f /opt/rh/gcc-toolset-13/enable ]; then
-            source /opt/rh/gcc-toolset-13/enable
-            echo "PATH=$PATH" >> $GITHUB_ENV
-            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
-            echo "CC=$(which gcc)" >> $GITHUB_ENV
-            echo "CXX=$(which g++)" >> $GITHUB_ENV
-            echo "GCC version: $(gcc --version | head -1)"
-          fi
-
-      - name: Install gh
-        run: |
-          if command -v gh >/dev/null 2>&1; then
-            echo "GitHub CLI already installed: $(gh --version | head -1)"
-          else
-            echo "Installing GitHub CLI..."
-            if command -v apt-get >/dev/null 2>&1; then
-              sudo mkdir -p -m 755 /etc/apt/keyrings
-              out=$(mktemp)
-              wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg
-              cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
-              sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
-              echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-              sudo apt update
-              sudo apt install gh -y
-            elif command -v dnf >/dev/null 2>&1; then
-              sudo dnf install -y 'dnf-command(config-manager)'
-              sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-              sudo dnf -y install gh --repo gh-cli
-            else
-              echo "Error: No supported package manager found (apt-get or dnf)"
-              exit 1
-            fi
-          fi
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure Git safe directory
         run: |
@@ -172,40 +81,6 @@ jobs:
           uv pip install -U pip setuptools==75.8.0 wheel packaging psutil auditwheel
           current_dir=$(pwd)
           echo "$current_dir/.venv/bin" >> $GITHUB_PATH
-
-          # Export Python include path for C extensions (Python.h)
-          # uv's standalone Python may report a wrong sysconfig include path
-          # (e.g. /usr/include/python3.12 which doesn't exist). Resolve the
-          # real Python binary and find the include directory relative to it.
-          REAL_PYTHON=$(readlink -f $current_dir/.venv/bin/python)
-          echo "Real Python binary: $REAL_PYTHON"
-          PYTHON_PREFIX=$(dirname $(dirname "$REAL_PYTHON"))
-          echo "Python prefix: $PYTHON_PREFIX"
-
-          # Search for Python.h in multiple locations:
-          # 1. uv managed Python directory
-          # 2. Python prefix from real binary
-          # 3. sysconfig reported path (fallback)
-          PYTHON_INCLUDE=""
-          UV_PYTHON_DIR="${UV_PYTHON_INSTALL_DIR:-$HOME/.local/share/uv/python}"
-          for search_dir in "$UV_PYTHON_DIR" "$PYTHON_PREFIX"; do
-            if [ -d "$search_dir" ]; then
-              found=$(find "$search_dir" -name "Python.h" -printf "%h" -quit 2>/dev/null || echo "")
-              if [ -n "$found" ]; then
-                PYTHON_INCLUDE="$found"
-                echo "Found Python.h in: $PYTHON_INCLUDE"
-                break
-              fi
-            fi
-          done
-
-          if [ -z "$PYTHON_INCLUDE" ]; then
-            # Fallback to sysconfig
-            PYTHON_INCLUDE=$($current_dir/.venv/bin/python -c "import sysconfig; print(sysconfig.get_path('include'))")
-            echo "Fallback to sysconfig: $PYTHON_INCLUDE"
-          fi
-          echo "Python include path: $PYTHON_INCLUDE"
-          echo "CPATH=$PYTHON_INCLUDE${CPATH:+:$CPATH}" >> $GITHUB_ENV
 
       - name: Setup CUDA
         uses: mjun0812/setup-cuda@v1
@@ -360,3 +235,9 @@ jobs:
           echo "=========================================="
           echo "Cleanup completed."
           echo "=========================================="
+
+      - name: Clean up
+        shell: bash
+        if: always()
+        run: |
+          rm -rf /opt/hostedtoolcache/Python

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -68,74 +68,93 @@ jobs:
 
       - name: Install tools
         run: |
-          # Auto-detect package manager and install dependencies
-          if command -v apt-get >/dev/null 2>&1; then
-            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-              curl \
-              ca-certificates \
-              sudo \
-              software-properties-common \
-              wget \
-              unzip \
-              zip \
-              git \
-              build-essential \
-              gcc \
-              g++ \
-              clang \
-              ninja-build \
-              keyboard-configuration \
-              time \
-              patchelf
-          elif command -v dnf >/dev/null 2>&1; then
-            sudo dnf install -y \
-              curl \
-              ca-certificates \
-              sudo \
-              wget \
-              unzip \
-              zip \
-              git \
-              gcc-toolset-13-gcc \
-              gcc-toolset-13-gcc-c++ \
-              clang \
-              ninja-build \
-              time \
-              patchelf
-            # Activate gcc-toolset-13 for CUDA compatibility
-            if [ -f /opt/rh/gcc-toolset-13/enable ]; then
-              # Export PATH and other env vars to GITHUB_ENV for subsequent steps
-              source /opt/rh/gcc-toolset-13/enable
-              echo "PATH=$PATH" >> $GITHUB_ENV
-              echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
-              echo "CC=$(which gcc)" >> $GITHUB_ENV
-              echo "CXX=$(which g++)" >> $GITHUB_ENV
-              echo "GCC version: $(gcc --version | head -1)"
+          # Check if key build tools are already installed
+          REQUIRED_CMDS=(gcc g++ clang ninja patchelf)
+          MISSING=false
+          for cmd in "${REQUIRED_CMDS[@]}"; do
+            if ! command -v "$cmd" >/dev/null 2>&1; then
+              echo "Missing: $cmd"
+              MISSING=true
             fi
+          done
+
+          if [ "$MISSING" = "false" ]; then
+            echo "All build tools already installed, skipping"
           else
-            echo "Error: No supported package manager found (apt-get or dnf)"
-            exit 1
+            echo "Installing build tools..."
+            # Auto-detect package manager and install dependencies
+            if command -v apt-get >/dev/null 2>&1; then
+              sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+                curl \
+                ca-certificates \
+                sudo \
+                software-properties-common \
+                wget \
+                unzip \
+                zip \
+                git \
+                build-essential \
+                gcc \
+                g++ \
+                clang \
+                ninja-build \
+                keyboard-configuration \
+                time \
+                patchelf
+            elif command -v dnf >/dev/null 2>&1; then
+              sudo dnf install -y \
+                curl \
+                ca-certificates \
+                sudo \
+                wget \
+                unzip \
+                zip \
+                git \
+                gcc-toolset-13-gcc \
+                gcc-toolset-13-gcc-c++ \
+                clang \
+                ninja-build \
+                time \
+                patchelf
+            else
+              echo "Error: No supported package manager found (apt-get or dnf)"
+              exit 1
+            fi
+          fi
+
+          # Activate gcc-toolset-13 for CUDA compatibility (always check, even if skipped install)
+          if [ -f /opt/rh/gcc-toolset-13/enable ]; then
+            source /opt/rh/gcc-toolset-13/enable
+            echo "PATH=$PATH" >> $GITHUB_ENV
+            echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
+            echo "CC=$(which gcc)" >> $GITHUB_ENV
+            echo "CXX=$(which g++)" >> $GITHUB_ENV
+            echo "GCC version: $(gcc --version | head -1)"
           fi
 
       - name: Install gh
         run: |
-          # Auto-detect package manager and install GitHub CLI
-          if command -v apt-get >/dev/null 2>&1; then
-            sudo mkdir -p -m 755 /etc/apt/keyrings
-            out=$(mktemp)
-            wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg
-            cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
-            sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt update
-            sudo apt install gh -y
-          elif command -v dnf >/dev/null 2>&1; then
-            sudo dnf install -y 'dnf-command(config-manager)'
-            sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-            sudo dnf -y install gh --repo gh-cli
+          if command -v gh >/dev/null 2>&1; then
+            echo "GitHub CLI already installed: $(gh --version | head -1)"
           else
-            echo "Error: No supported package manager found (apt-get or dnf)"
-            exit 1
+            echo "Installing GitHub CLI..."
+            if command -v apt-get >/dev/null 2>&1; then
+              sudo mkdir -p -m 755 /etc/apt/keyrings
+              out=$(mktemp)
+              wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg
+              cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+              sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+              echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+              sudo apt update
+              sudo apt install gh -y
+            elif command -v dnf >/dev/null 2>&1; then
+              sudo dnf install -y 'dnf-command(config-manager)'
+              sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+              sudo dnf -y install gh --repo gh-cli
+            else
+              echo "Error: No supported package manager found (apt-get or dnf)"
+              exit 1
+            fi
           fi
 
       - uses: actions/checkout@v4

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -1,0 +1,309 @@
+# #########################################################
+# Build wheels with self-hosted runner (no container)
+# #########################################################
+# Prerequisites (must be pre-installed on the runner):
+#   - sudo access
+#   - Basic tools: curl, wget, git
+#
+# All other dependencies (build tools, Python, CUDA, gh CLI)
+# are installed during the workflow and cleaned up afterwards.
+# #########################################################
+
+name: "[Linux, self-hosted, no container] Build wheels and upload to GitHub Releases"
+
+on:
+  workflow_call:
+    inputs:
+      flash-attn-version:
+        description: "Flash-Attention version"
+        required: true
+        type: string
+      python-version:
+        description: "Python version"
+        required: true
+        type: string
+      torch-version:
+        description: "PyTorch version"
+        required: true
+        type: string
+      cuda-version:
+        description: "CUDA version"
+        required: true
+        type: string
+      runner:
+        description: "Runner type"
+        required: false
+        type: string
+        default: '["self-hosted", "Linux", "x64"]'
+      is-upload:
+        description: "Whether to upload the release asset"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  build_wheels_no_container:
+    name: Build wheels and Upload (Linux, self-hosted, no container)
+    runs-on: ${{ fromjson(inputs.runner) }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TERM: xterm-256color
+    timeout-minutes: 2160
+
+    steps:
+      - name: Check environment
+        run: |
+          cat /etc/os-release || true
+          echo "-----------------------------"
+          cat /etc/lsb-release || true
+          echo "-----------------------------"
+          lscpu || true
+          echo "-----------------------------"
+          df -h || true
+          echo "-----------------------------"
+          free -h || true
+
+      - name: Install tools
+        run: |
+          # Auto-detect package manager and install dependencies
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+              curl \
+              ca-certificates \
+              sudo \
+              software-properties-common \
+              wget \
+              unzip \
+              zip \
+              git \
+              build-essential \
+              gcc \
+              g++ \
+              clang \
+              ninja-build \
+              keyboard-configuration \
+              time \
+              patchelf
+          elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y \
+              curl \
+              ca-certificates \
+              sudo \
+              wget \
+              unzip \
+              zip \
+              git \
+              gcc-toolset-13-gcc \
+              gcc-toolset-13-gcc-c++ \
+              clang \
+              ninja-build \
+              time \
+              patchelf
+            # Activate gcc-toolset-13 for CUDA compatibility
+            if [ -f /opt/rh/gcc-toolset-13/enable ]; then
+              # Export PATH and other env vars to GITHUB_ENV for subsequent steps
+              source /opt/rh/gcc-toolset-13/enable
+              echo "PATH=$PATH" >> $GITHUB_ENV
+              echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
+              echo "CC=$(which gcc)" >> $GITHUB_ENV
+              echo "CXX=$(which g++)" >> $GITHUB_ENV
+              echo "GCC version: $(gcc --version | head -1)"
+            fi
+          else
+            echo "Error: No supported package manager found (apt-get or dnf)"
+            exit 1
+          fi
+
+      - name: Install gh
+        run: |
+          # Auto-detect package manager and install GitHub CLI
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo mkdir -p -m 755 /etc/apt/keyrings
+            out=$(mktemp)
+            wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg
+            cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+            sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt update
+            sudo apt install gh -y
+          elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf install -y 'dnf-command(config-manager)'
+            sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+            sudo dnf -y install gh --repo gh-cli
+          else
+            echo "Error: No supported package manager found (apt-get or dnf)"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Configure Git safe directory
+        run: |
+          git config --global --add safe.directory $(pwd)
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: |
+          uv venv -p ${{ inputs.python-version }}
+          uv pip install -U pip setuptools==75.8.0 wheel packaging psutil auditwheel
+          current_dir=$(pwd)
+          echo "$current_dir/.venv/bin" >> $GITHUB_PATH
+
+      - name: Setup CUDA
+        uses: mjun0812/setup-cuda@v1
+        with:
+          version: ${{ inputs.cuda-version }}
+
+      - name: Build wheels
+        id: build_wheels
+        run: |
+          chmod +x build_linux.sh
+          ./build_linux.sh ${{ inputs.flash-attn-version }} ${{ inputs.python-version }} ${{ inputs.torch-version }} ${{ inputs.cuda-version }}
+          if [[ "${{ inputs.flash-attn-version }}" == fa3:* ]]; then
+            wheel_path=$(ls flash-attention/hopper/dist/*.whl | head -n 1)
+            echo "IS_FA3=true" >> $GITHUB_OUTPUT
+          else
+            wheel_path=$(ls flash-attention/dist/*.whl | head -n 1)
+            echo "IS_FA3=false" >> $GITHUB_OUTPUT
+          fi
+          echo "WHEEL_PATH=$wheel_path" >> $GITHUB_OUTPUT
+
+      - name: Install Test
+        run: |
+          if [ "${{ steps.build_wheels.outputs.IS_FA3 }}" = "true" ]; then
+            pip uninstall -y flash-attn-3 > /dev/null 2>&1
+            pip install --no-cache-dir ${{ steps.build_wheels.outputs.WHEEL_PATH }}
+            python -c "import flash_attn_3; from importlib.metadata import version; print(version('flash-attn-3'))"
+          else
+            pip uninstall -y flash-attn > /dev/null 2>&1
+            pip install --no-cache-dir ${{ steps.build_wheels.outputs.WHEEL_PATH }}
+            python -c "import flash_attn; print(flash_attn.__version__)"
+          fi
+
+      - name: Upload Release Asset
+        if: ${{ inputs.is-upload }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag_name=${{ github.ref_name }}
+          wheel_path="${{ steps.build_wheels.outputs.WHEEL_PATH }}"
+          # Check if the file exists
+          if [ ! -f "$wheel_path" ]; then
+            echo "Error: Wheel file not found at $wheel_path"
+            exit 1
+          fi
+          # Upload the release asset using GitHub CLI
+          gh release upload "$tag_name" "$wheel_path" --clobber
+
+      - name: Apply auditwheel repair
+        continue-on-error: true
+        id: auditwheel_repair
+        run: |
+          if [ "${{ steps.build_wheels.outputs.IS_FA3 }}" = "true" ]; then
+            DIST_MANYLINUX_DIR="flash-attention/hopper/dist_manylinux"
+          else
+            DIST_MANYLINUX_DIR="flash-attention/dist_manylinux"
+          fi
+          auditwheel show ${{ steps.build_wheels.outputs.WHEEL_PATH }}
+          auditwheel repair \
+            --exclude libc10* --exclude libtorch* --exclude libcu* --exclude libnv* --exclude 'libtorch*' \
+            ${{ steps.build_wheels.outputs.WHEEL_PATH }} -w "$DIST_MANYLINUX_DIR"
+          wheel_path_manylinux=$(ls "$DIST_MANYLINUX_DIR"/*manylinux*.whl 2>/dev/null | head -n 1 || echo "")
+          echo "WHEEL_PATH_MANYLINUX=$wheel_path_manylinux" >> $GITHUB_OUTPUT
+
+      - name: Test manylinux wheel
+        continue-on-error: true
+        run: |
+          if [ -n "${{ steps.auditwheel_repair.outputs.WHEEL_PATH_MANYLINUX }}" ] && [ -f "${{ steps.auditwheel_repair.outputs.WHEEL_PATH_MANYLINUX }}" ]; then
+            if [ "${{ steps.build_wheels.outputs.IS_FA3 }}" = "true" ]; then
+              pip uninstall -y flash-attn-3 > /dev/null 2>&1
+              pip install --no-cache-dir ${{ steps.auditwheel_repair.outputs.WHEEL_PATH_MANYLINUX }}
+              python -c "import flash_attn_3; from importlib.metadata import version; print(version('flash-attn-3'))"
+            else
+              pip uninstall -y flash-attn > /dev/null 2>&1
+              pip install --no-cache-dir ${{ steps.auditwheel_repair.outputs.WHEEL_PATH_MANYLINUX }}
+              python -c "import flash_attn; print(flash_attn.__version__)"
+            fi
+          fi
+
+      - name: Upload manylinux wheel
+        if: ${{ inputs.is-upload }}
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag_name=${{ github.ref_name }}
+          wheel_path_manylinux="${{ steps.auditwheel_repair.outputs.WHEEL_PATH_MANYLINUX }}"
+          if [ -n "$wheel_path_manylinux" ] && [ -f "$wheel_path_manylinux" ]; then
+            # Upload the release asset using GitHub CLI
+            gh release upload "$tag_name" "$wheel_path_manylinux" --clobber
+          else
+            echo "Skipping manylinux wheel upload: file not found"
+          fi
+
+      # Cleanup step - always runs even if previous steps fail
+      - name: Cleanup (always run)
+        if: always()
+        run: |
+          echo "=========================================="
+          echo "Starting cleanup for self-hosted runner..."
+          echo "=========================================="
+
+          # 1. Remove flash-attention directory (source and build artifacts)
+          FLASH_ATTN_DIR="$(pwd)/flash-attention"
+          if [ -d "$FLASH_ATTN_DIR" ]; then
+            echo "[1/6] Removing flash-attention directory: $FLASH_ATTN_DIR"
+            rm -rf "$FLASH_ATTN_DIR" || true
+          else
+            echo "[1/6] flash-attention directory not found, skipping"
+          fi
+
+          # 2. Remove Python virtual environment (.venv)
+          VENV_DIR="$(pwd)/.venv"
+          if [ -d "$VENV_DIR" ]; then
+            echo "[2/6] Removing Python virtual environment: $VENV_DIR"
+            rm -rf "$VENV_DIR" || true
+          else
+            echo "[2/6] .venv directory not found, skipping"
+          fi
+
+          # 3. Remove pip cache
+          PIP_CACHE_DIR="$HOME/.cache/pip"
+          if [ -d "$PIP_CACHE_DIR" ]; then
+            echo "[3/6] Removing pip cache: $PIP_CACHE_DIR"
+            rm -rf "$PIP_CACHE_DIR" || true
+          else
+            echo "[3/6] pip cache not found, skipping"
+          fi
+
+          # 4. Remove uv cache
+          UV_CACHE_DIR="$HOME/.cache/uv"
+          if [ -d "$UV_CACHE_DIR" ]; then
+            echo "[4/6] Removing uv cache: $UV_CACHE_DIR"
+            rm -rf "$UV_CACHE_DIR" || true
+          else
+            echo "[4/6] uv cache not found, skipping"
+          fi
+
+          # 5. Uninstall CUDA
+          echo "[5/6] Removing CUDA installation..."
+          if command -v apt-get >/dev/null 2>&1; then
+            sudo apt-get remove -y --purge 'cuda*' 'libcudnn*' 'libnccl*' 2>/dev/null || true
+            sudo apt-get autoremove -y 2>/dev/null || true
+          elif command -v dnf >/dev/null 2>&1; then
+            sudo dnf remove -y 'cuda*' 'libcudnn*' 'libnccl*' 2>/dev/null || true
+          fi
+          sudo rm -rf /usr/local/cuda* || true
+
+          # 6. Remove temp files
+          echo "[6/6] Removing temporary files"
+          rm -rf /tmp/pip-* /tmp/torch* /tmp/cuda* /tmp/flash* /tmp/uv-* 2>/dev/null || true
+
+          echo "=========================================="
+          echo "Cleanup completed."
+          echo "=========================================="

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -176,7 +176,8 @@ jobs:
           # Export Python include path for C extensions (Python.h)
           # uv's standalone Python stores headers under the managed Python,
           # not under /usr/include, so we need to add it to CPATH.
-          PYTHON_INCLUDE=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")
+          # Use .venv/bin/python directly since GITHUB_PATH is not yet active in this step.
+          PYTHON_INCLUDE=$($current_dir/.venv/bin/python -c "import sysconfig; print(sysconfig.get_path('include'))")
           echo "Python include path: $PYTHON_INCLUDE"
           echo "CPATH=$PYTHON_INCLUDE${CPATH:+:$CPATH}" >> $GITHUB_ENV
 

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -173,6 +173,13 @@ jobs:
           current_dir=$(pwd)
           echo "$current_dir/.venv/bin" >> $GITHUB_PATH
 
+          # Export Python include path for C extensions (Python.h)
+          # uv's standalone Python stores headers under the managed Python,
+          # not under /usr/include, so we need to add it to CPATH.
+          PYTHON_INCLUDE=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")
+          echo "Python include path: $PYTHON_INCLUDE"
+          echo "CPATH=$PYTHON_INCLUDE${CPATH:+:$CPATH}" >> $GITHUB_ENV
+
       - name: Setup CUDA
         uses: mjun0812/setup-cuda@v1
         with:

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -88,10 +88,13 @@ jobs:
           version: ${{ inputs.cuda-version }}
 
       - name: Build wheels
-        id: build_wheels
         run: |
           chmod +x build_linux.sh
           ./build_linux.sh ${{ inputs.flash-attn-version }} ${{ inputs.python-version }} ${{ inputs.torch-version }} ${{ inputs.cuda-version }}
+
+      - name: Locate wheel
+        id: build_wheels
+        run: |
           if [[ "${{ inputs.flash-attn-version }}" == fa3:* ]]; then
             wheel_path=$(ls flash-attention/hopper/dist/*.whl | head -n 1)
             echo "IS_FA3=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -82,6 +82,57 @@ jobs:
           current_dir=$(pwd)
           echo "$current_dir/.venv/bin" >> $GITHUB_PATH
 
+      - name: Debug Python include paths
+        run: |
+          echo "===== Python binary info ====="
+          which python
+          python --version
+          REAL_PYTHON=$(readlink -f $(which python))
+          echo "Real python binary: $REAL_PYTHON"
+
+          echo ""
+          echo "===== sysconfig paths ====="
+          python -c "
+          import sysconfig
+          print('include:', sysconfig.get_path('include'))
+          print('platinclude:', sysconfig.get_path('platinclude'))
+          print('prefix:', sysconfig.get_config_var('prefix'))
+          print('INCLUDEPY:', sysconfig.get_config_var('INCLUDEPY'))
+          print('installed_base:', sysconfig.get_config_var('installed_base'))
+          "
+
+          echo ""
+          echo "===== Check if Python.h exists at sysconfig path ====="
+          INCLUDE_PATH=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")
+          echo "sysconfig include path: $INCLUDE_PATH"
+          if [ -f "$INCLUDE_PATH/Python.h" ]; then
+            echo "OK: Python.h found at $INCLUDE_PATH/Python.h"
+          else
+            echo "NOT FOUND: Python.h not at $INCLUDE_PATH/Python.h"
+          fi
+
+          echo ""
+          echo "===== .venv/include contents ====="
+          ls -la .venv/include/ 2>/dev/null || echo ".venv/include/ does not exist"
+          ls -la .venv/include/*/ 2>/dev/null || echo "No subdirectories in .venv/include/"
+
+          echo ""
+          echo "===== uv python directory ====="
+          UV_PYTHON_DIR="${HOME}/.local/share/uv/python"
+          echo "UV_PYTHON_DIR: $UV_PYTHON_DIR"
+          ls -la "$UV_PYTHON_DIR/" 2>/dev/null || echo "uv python dir not found"
+
+          echo ""
+          echo "===== Search for Python.h ====="
+          # Search in uv managed directory
+          find "$UV_PYTHON_DIR" -name "Python.h" 2>/dev/null | head -5 || echo "Not found in uv dir"
+          # Search in venv
+          find .venv -name "Python.h" 2>/dev/null | head -5 || echo "Not found in .venv"
+          # Search in real python prefix
+          REAL_PREFIX=$(dirname $(dirname "$REAL_PYTHON"))
+          echo "Real python prefix: $REAL_PREFIX"
+          find "$REAL_PREFIX" -name "Python.h" 2>/dev/null | head -5 || echo "Not found in real prefix"
+
       - name: Setup CUDA
         uses: mjun0812/setup-cuda@v1
         with:

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -83,7 +83,7 @@ jobs:
           echo "$current_dir/.venv/bin" >> $GITHUB_PATH
 
       - name: Setup CUDA
-        uses: mjun0812/setup-cuda@v1
+        uses: mjun0812/setup-cuda@v1.3.0
         with:
           version: ${{ inputs.cuda-version }}
 

--- a/.github/workflows/_build_linux_no_container.yml
+++ b/.github/workflows/_build_linux_no_container.yml
@@ -178,11 +178,31 @@ jobs:
           # (e.g. /usr/include/python3.12 which doesn't exist). Resolve the
           # real Python binary and find the include directory relative to it.
           REAL_PYTHON=$(readlink -f $current_dir/.venv/bin/python)
+          echo "Real Python binary: $REAL_PYTHON"
           PYTHON_PREFIX=$(dirname $(dirname "$REAL_PYTHON"))
-          PYTHON_INCLUDE=$(find "$PYTHON_PREFIX/include" -name "Python.h" -printf "%h" -quit 2>/dev/null || echo "")
+          echo "Python prefix: $PYTHON_PREFIX"
+
+          # Search for Python.h in multiple locations:
+          # 1. uv managed Python directory
+          # 2. Python prefix from real binary
+          # 3. sysconfig reported path (fallback)
+          PYTHON_INCLUDE=""
+          UV_PYTHON_DIR="${UV_PYTHON_INSTALL_DIR:-$HOME/.local/share/uv/python}"
+          for search_dir in "$UV_PYTHON_DIR" "$PYTHON_PREFIX"; do
+            if [ -d "$search_dir" ]; then
+              found=$(find "$search_dir" -name "Python.h" -printf "%h" -quit 2>/dev/null || echo "")
+              if [ -n "$found" ]; then
+                PYTHON_INCLUDE="$found"
+                echo "Found Python.h in: $PYTHON_INCLUDE"
+                break
+              fi
+            fi
+          done
+
           if [ -z "$PYTHON_INCLUDE" ]; then
             # Fallback to sysconfig
             PYTHON_INCLUDE=$($current_dir/.venv/bin/python -c "import sysconfig; print(sysconfig.get_path('include'))")
+            echo "Fallback to sysconfig: $PYTHON_INCLUDE"
           fi
           echo "Python include path: $PYTHON_INCLUDE"
           echo "CPATH=$PYTHON_INCLUDE${CPATH:+:$CPATH}" >> $GITHUB_ENV

--- a/.github/workflows/_build_linux_self_host.yml
+++ b/.github/workflows/_build_linux_self_host.yml
@@ -147,7 +147,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure Git safe directory
         shell: bash
@@ -263,7 +263,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure Git safe directory
         shell: bash

--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build wheels and Upload (Windows x86_64, GitHub hosted runner)
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Enable Git long paths
         shell: pwsh

--- a/.github/workflows/_build_windows_code_build.yml
+++ b/.github/workflows/_build_windows_code_build.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: codebuild-flash-attention-pre-build-wheel-windows-${{ github.run_id }}-${{ github.run_attempt }}
     # Large Instance
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Enable Git long paths
         shell: pwsh

--- a/.github/workflows/_build_windows_self_host.yml
+++ b/.github/workflows/_build_windows_self_host.yml
@@ -86,15 +86,22 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
 
+      - name: Set OEM code page to UTF-8
+        shell: pwsh
+        run: |
+          # PyTorch cpp_extension.py uses Python's 'oem' codec to decode
+          # cl.exe output. On Japanese Windows, the OEM code page (cp932)
+          # cannot decode certain bytes from MSVC. Override the system OEM
+          # and ANSI code pages to UTF-8 (65001) via registry.
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage' -Name 'OEMCP' -Value '65001'
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage' -Name 'ACP' -Value '65001'
+
       - name: Build wheels
         shell: pwsh
         timeout-minutes: 2160
         env:
           PYTHONUTF8: "1"
         run: |
-          # Set console code page to UTF-8 to avoid UnicodeDecodeError
-          # in torch cpp_extension when detecting compiler version
-          chcp 65001
           .\build_windows.ps1 -FlashAttnVersion "${{ inputs.flash-attn-version }}" -PythonVersion "${{ inputs.python-version }}" -TorchVersion "${{ inputs.torch-version }}" -CudaVersion "${{ inputs.cuda-version }}"
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
@@ -232,6 +239,11 @@ jobs:
               Remove-Item -Path $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
             }
           }
+
+          # 7. Restore OEM/ANSI code page to original values (Japanese: 932/932)
+          Write-Host "[7/7] Restoring OEM/ANSI code page..."
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage' -Name 'OEMCP' -Value '932' -ErrorAction SilentlyContinue
+          Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage' -Name 'ACP' -Value '932' -ErrorAction SilentlyContinue
 
           Write-Host "=========================================="
           Write-Host "Cleanup completed."

--- a/.github/workflows/_build_windows_self_host.yml
+++ b/.github/workflows/_build_windows_self_host.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ fromjson(inputs.runner) }}
     timeout-minutes: 2160
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Enable Git long paths
         shell: pwsh

--- a/.github/workflows/_build_windows_self_host.yml
+++ b/.github/workflows/_build_windows_self_host.yml
@@ -89,7 +89,12 @@ jobs:
       - name: Build wheels
         shell: pwsh
         timeout-minutes: 2160
+        env:
+          PYTHONUTF8: "1"
         run: |
+          # Set console code page to UTF-8 to avoid UnicodeDecodeError
+          # in torch cpp_extension when detecting compiler version
+          chcp 65001
           .\build_windows.ps1 -FlashAttnVersion "${{ inputs.flash-attn-version }}" -PythonVersion "${{ inputs.python-version }}" -TorchVersion "${{ inputs.torch-version }}" -CudaVersion "${{ inputs.cuda-version }}"
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create Releases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -25,7 +25,7 @@ jobs:
     outputs:
       matrix: ${{ steps.create_matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Create Matrix
@@ -252,7 +252,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -285,7 +285,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,49 @@ jobs:
       container-image: "quay.io/pypa/manylinux_2_28_aarch64"
     secrets: inherit
 
+  # ################ Self-hosted runner (no container) ################
+  build_wheels_linux_no_container:
+    name: Build Linux (no container)
+    needs: [create_releases, create_matrix]
+    if: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_no_container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        flash-attn-version: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_no_container.flash-attn-version }}
+        python-version: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_no_container.python-version }}
+        torch-version: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_no_container.torch-version }}
+        cuda-version: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_no_container.cuda-version }}
+        exclude: ${{ fromjson(needs.create_matrix.outputs.matrix).exclude }}
+    uses: ./.github/workflows/_build_linux_no_container.yml
+    with:
+      flash-attn-version: ${{ matrix.flash-attn-version }}
+      python-version: ${{ matrix.python-version }}
+      torch-version: ${{ matrix.torch-version }}
+      cuda-version: ${{ matrix.cuda-version }}
+      runner: '["self-hosted", "Linux", "x64"]'
+    secrets: inherit
+
+  build_wheels_linux_arm64_no_container:
+    name: Build Linux ARM64 (no container)
+    needs: [create_releases, create_matrix]
+    if: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_arm64_no_container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        flash-attn-version: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_arm64_no_container.flash-attn-version }}
+        python-version: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_arm64_no_container.python-version }}
+        torch-version: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_arm64_no_container.torch-version }}
+        cuda-version: ${{ fromjson(needs.create_matrix.outputs.matrix).linux_arm64_no_container.cuda-version }}
+        exclude: ${{ fromjson(needs.create_matrix.outputs.matrix).exclude }}
+    uses: ./.github/workflows/_build_linux_no_container.yml
+    with:
+      flash-attn-version: ${{ matrix.flash-attn-version }}
+      python-version: ${{ matrix.python-version }}
+      torch-version: ${{ matrix.torch-version }}
+      cuda-version: ${{ matrix.cuda-version }}
+      runner: '["self-hosted-arm", "arm64"]'
+    secrets: inherit
+
   # #########################################################
   # Windows
   # #########################################################
@@ -201,6 +244,8 @@ jobs:
       - build_wheels_linux_arm64
       - build_wheels_linux_self_hosted
       - build_wheels_linux_arm64_self_hosted
+      - build_wheels_linux_no_container
+      - build_wheels_linux_arm64_no_container
       - build_wheels_windows
       - build_wheels_windows_code_build
       - build_wheels_windows_self_hosted
@@ -227,6 +272,8 @@ jobs:
       - build_wheels_linux_arm64
       - build_wheels_linux_self_hosted
       - build_wheels_linux_arm64_self_hosted
+      - build_wheels_linux_no_container
+      - build_wheels_linux_arm64_no_container
       - build_wheels_windows
       - build_wheels_windows_code_build
       - build_wheels_windows_self_hosted

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -3,6 +3,10 @@
 #
 # Select a platform from the dropdown to trigger a test build.
 # All builds set is-upload: false (no release upload).
+# Example usage:
+#   gh workflow run "Test build" --ref main \
+#   -f platform=linux-arm64-no-container -f flash-attn-version=2.8.3 \
+#   -f python-version=3.12 -f torch-version=2.10.0 -f cuda-version=12.8
 # #########################################################
 
 name: Test build

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -16,8 +16,10 @@ on:
         type: choice
         options:
           - linux-x64-self-hosted
+          - linux-x64-no-container
           - linux-arm64
           - linux-arm64-self-hosted
+          - linux-arm64-no-container
           - windows-self-hosted
           - windows-github-hosted
           - windows-codebuild
@@ -59,6 +61,20 @@ jobs:
       use-container: true
 
   # #########################################################
+  # Linux x86_64 self-hosted runner (no container)
+  # #########################################################
+  linux-x64-no-container:
+    if: inputs.platform == 'linux-x64-no-container'
+    uses: ./.github/workflows/_build_linux_no_container.yml
+    with:
+      flash-attn-version: ${{ inputs.flash-attn-version }}
+      python-version: ${{ inputs.python-version }}
+      torch-version: ${{ inputs.torch-version }}
+      cuda-version: ${{ inputs.cuda-version }}
+      is-upload: false
+      runner: '["self-hosted", "Linux", "x64"]'
+
+  # #########################################################
   # Linux ARM64 GitHub-hosted runner
   # #########################################################
   linux-arm64:
@@ -86,6 +102,20 @@ jobs:
       is-upload: false
       runner: '["self-hosted-arm"]'
       container-image: "quay.io/pypa/manylinux_2_28_aarch64"
+
+  # #########################################################
+  # Linux ARM64 self-hosted runner (no container)
+  # #########################################################
+  linux-arm64-no-container:
+    if: inputs.platform == 'linux-arm64-no-container'
+    uses: ./.github/workflows/_build_linux_no_container.yml
+    with:
+      flash-attn-version: ${{ inputs.flash-attn-version }}
+      python-version: ${{ inputs.python-version }}
+      torch-version: ${{ inputs.torch-version }}
+      cuda-version: ${{ inputs.cuda-version }}
+      is-upload: false
+      runner: '["self-hosted-arm", "arm64"]'
 
   # #########################################################
   # Windows x86_64 self-hosted runner

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -115,7 +115,7 @@ jobs:
       torch-version: ${{ inputs.torch-version }}
       cuda-version: ${{ inputs.cuda-version }}
       is-upload: false
-      runner: '["self-hosted-arm", "arm64"]'
+      runner: '["self-hosted-arm"]'
 
   # #########################################################
   # Windows x86_64 self-hosted runner

--- a/.github/workflows/update-download-stats.yml
+++ b/.github/workflows/update-download-stats.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/create_matrix.py
+++ b/create_matrix.py
@@ -134,6 +134,72 @@ LINUX_ARM64_SELF_HOSTED_MATRIX = {
     ],
 }
 
+LINUX_NO_CONTAINER_MATRIX = {
+    "flash-attn-version": [
+        "2.6.3",
+        "2.7.4",
+        "2.8.3",
+        FA3_COMMIT,
+    ],
+    "python-version": [
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+        "3.14t",
+    ],
+    "torch-version": [
+        # "2.5.1",
+        # "2.6.0",
+        # "2.7.1",
+        # "2.8.0",
+        # "2.9.1",
+        # "2.10.0",
+        "2.11.0",
+    ],
+    "cuda-version": [
+        # "12.4",
+        "12.6",
+        "12.8",
+        # "12.9",
+        "13.0",
+    ],
+}
+
+LINUX_ARM64_NO_CONTAINER_MATRIX = {
+    "flash-attn-version": [
+        # "2.6.3",
+        # "2.7.4",
+        # "2.8.3",
+        FA3_COMMIT,
+    ],
+    "python-version": [
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+        "3.14t",
+    ],
+    "torch-version": [
+        "2.5.1",
+        "2.6.0",
+        "2.7.1",
+        "2.8.0",
+        "2.9.1",
+        "2.10.0",
+        "2.11.0",
+    ],
+    "cuda-version": [
+        "12.4",
+        "12.6",
+        "12.8",
+        "12.9",
+        "13.0",
+    ],
+}
+
 WINDOWS_MATRIX = {
     "flash-attn-version": [
         "2.8.3",
@@ -232,6 +298,12 @@ def main():
                 #
                 "linux_arm64_self_hosted": False,
                 # "linux_arm64_self_hosted": LINUX_ARM64_SELF_HOSTED_MATRIX,
+                #
+                "linux_no_container": False,
+                # "linux_no_container": LINUX_NO_CONTAINER_MATRIX,
+                #
+                "linux_arm64_no_container": False,
+                # "linux_arm64_no_container": LINUX_ARM64_NO_CONTAINER_MATRIX,
                 #
                 "windows": False,
                 # "windows": WINDOWS_MATRIX,

--- a/self-hosted-runner/Dockerfile
+++ b/self-hosted-runner/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 RUN mkdir -p /opt/hostedtoolcache \
     && chown -R ubuntu:ubuntu /opt/hostedtoolcache
 
-RUN apt-get update && apt-get install -y --no-install-recommends\
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     sudo \
@@ -18,6 +18,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends\
     zip \
     git \
     libc-bin \
+    build-essential \
+    gcc \
+    g++ \
+    clang \
+    ninja-build \
+    keyboard-configuration \
+    time \
+    patchelf \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Docker
@@ -37,6 +45,16 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     docker-buildx-plugin \
     docker-compose-plugin \
     && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && mkdir -p -m 755 /etc/apt/sources.list.d \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt update \
+    && apt install gh -y
 
 # Install dotnet
 RUN add-apt-repository ppa:dotnet/backports

--- a/self-hosted-runner/Dockerfile
+++ b/self-hosted-runner/Dockerfile
@@ -1,6 +1,9 @@
-FROM ubuntu:24.04
+ARG PLATFORM="linux/amd64"
+
+FROM --platform=${PLATFORM} ubuntu:24.04
 
 ARG GH_RUNNER_VERSION="2.331.0"
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive \
     AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
@@ -68,8 +71,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 
 WORKDIR /home/ubuntu
 USER ubuntu
-
-ARG TARGETARCH
 
 RUN case "${TARGETARCH}" in \
     amd64) ARCH="x64" ;; \

--- a/self-hosted-runner/README.md
+++ b/self-hosted-runner/README.md
@@ -5,10 +5,27 @@ This directory contains the Docker-based self-hosted runner configuration for bu
 In some version combinations, you cannot build wheels on GitHub-hosted runners due to job time limitations.
 To build the wheels for these versions, you can use self-hosted runners.
 
+## Services
+
+| Service      | Description                                             | Architecture |
+| ------------ | ------------------------------------------------------- | ------------ |
+| `runner`     | Native architecture runner with Docker-in-Docker (DinD) | Host native  |
+| `runner-arm` | ARM64 runner via QEMU emulation (no DinD)               | arm64        |
+
+The `runner` service uses Docker-in-Docker to run container-based workflow jobs.
+The `runner-arm` service runs under QEMU emulation and is intended for no-container workflow jobs that execute directly on the runner.
+
 ## Prerequisites
 
 - Docker and Docker Compose
+- QEMU user static binaries (for `runner-arm`)
 - GitHub Personal Access Token or Runner Registration Token
+
+To set up QEMU for ARM64 emulation:
+
+```bash
+sudo apt install qemu-user-static
+```
 
 ## Getting One-Time Registry Token for GitHub Actions Runner
 
@@ -27,17 +44,20 @@ git clone https://github.com/mjun0812/flash-attention-prebuild-wheels.git
 cd flash-attention-prebuild-wheels/self-hosted-runner
 ```
 
-### 2. Create environment file
+### 2. Create environment files
 
-Create an environment file from the template.
+Create environment files from the template.
 
 ```bash
+# For native runner
 cp env.template .env
+# For ARM64 QEMU runner
+cp env.template .env.arm
 ```
 
-### 3. Edit the environment file
+### 3. Edit the environment files
 
-Set the required variables in the `.env` file.
+Set the required variables in each `.env` file.
 
 ```bash
 # GitHub Personal Access Token (recommended)
@@ -60,45 +80,60 @@ services:
   runner:
     environment:
       REPOSITORY_URL: https://github.com/[YOUR_USERNAME]/flash-attention-prebuild-wheels
+  runner-arm:
+    environment:
+      REPOSITORY_URL: https://github.com/[YOUR_USERNAME]/flash-attention-prebuild-wheels
 ```
 
 ### 5. Build and run
 
 ```bash
+# Native runner
 docker compose build runner
 docker compose up -d runner
+
+# ARM64 QEMU runner
+docker compose build runner-arm
+docker compose up -d runner-arm
 ```
 
 ## Configuration
 
 ### Environment Variables
 
-| Variable               | Required | Description                                   |
-| ---------------------- | -------- | --------------------------------------------- |
-| `PERSONAL_ACCESS_TOKEN`| Either   | GitHub Personal Access Token                   |
-| `REGISTRY_TOKEN`       | Either   | One-time Runner Registration Token             |
-| `RUNNER_LABELS`        | No       | Comma-separated labels (default: `Linux,self-hosted`) |
+| Variable                | Required | Description                                           |
+| ----------------------- | -------- | ----------------------------------------------------- |
+| `PERSONAL_ACCESS_TOKEN` | Either   | GitHub Personal Access Token                          |
+| `REGISTRY_TOKEN`        | Either   | One-time Runner Registration Token                    |
+| `RUNNER_LABELS`         | No       | Comma-separated labels (default: `Linux,self-hosted`) |
 
 ### compose.yml Variables
 
-| Variable         | Description                                    | Default                  |
-| ---------------- | ---------------------------------------------- | ------------------------ |
-| `REPOSITORY_URL` | Target GitHub repository URL                   | This repository          |
-| `RUNNER_NAME`    | Name of the runner                             | `self-hosted-runner`     |
-| `RUNNER_GROUP`   | Runner group                                   | `default`                |
+| Variable         | Description                  | Default (`runner`)   | Default (`runner-arm`)        |
+| ---------------- | ---------------------------- | -------------------- | ----------------------------- |
+| `REPOSITORY_URL` | Target GitHub repository URL | This repository      | This repository               |
+| `RUNNER_NAME`    | Name of the runner           | `self-hosted-runner` | `self-hosted-runner-arm-qemu` |
+| `RUNNER_GROUP`   | Runner group                 | `default`            | `default`                     |
 
 ### Dockerfile Build Args
 
-| Arg                 | Description                        | Default    |
-| ------------------- | ---------------------------------- | ---------- |
-| `GH_RUNNER_VERSION` | GitHub Actions Runner version      | `2.331.0`  |
+| Arg                 | Description                   | Default   |
+| ------------------- | ----------------------------- | --------- |
+| `GH_RUNNER_VERSION` | GitHub Actions Runner version | `2.331.0` |
 
 ## Architecture
 
-The container runs the following:
+### Native runner (`runner`)
 
 1. Starts Docker daemon (Docker-in-Docker via privileged mode)
 2. Configures the GitHub Actions runner with the provided credentials
 3. Starts the runner process
 
-The container uses `ubuntu:24.04` as base image and includes Docker CE for building wheels inside the runner.
+### ARM64 QEMU runner (`runner-arm`)
+
+1. Detects aarch64 architecture and applies QEMU workarounds (disables iptables/ip6tables)
+2. Starts Docker daemon
+3. Configures the GitHub Actions runner with the provided credentials
+4. Starts the runner process
+
+Both containers use `ubuntu:24.04` as the base image. The native runner includes Docker CE for running container-based workflow jobs.

--- a/self-hosted-runner/compose.yml
+++ b/self-hosted-runner/compose.yml
@@ -20,6 +20,7 @@ services:
   # Qemu Runner (Arm64)
   runner-arm:
     platform: linux/arm64
+    privileged: true
     restart: always
     env_file:
       - .env.arm

--- a/self-hosted-runner/compose.yml
+++ b/self-hosted-runner/compose.yml
@@ -1,4 +1,5 @@
 services:
+  # Native Arch Runner
   runner:
     privileged: true
     restart: always
@@ -15,6 +16,23 @@ services:
         GH_RUNNER_VERSION: 2.331.0
     volumes:
       - fa-self:/var/lib/docker
+
+  # Qemu Runner (Arm64)
+  runner-arm:
+    platform: linux/arm64
+    restart: always
+    env_file:
+      - .env.arm
+    environment:
+      REPOSITORY_URL: https://github.com/mjun0812/flash-attention-prebuild-wheels
+      RUNNER_NAME: self-hosted-runner-arm-qemu
+      RUNNER_GROUP: default
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        GH_RUNNER_VERSION: 2.331.0
+        PLATFORM: linux/arm64
 
 volumes:
   fa-self:

--- a/self-hosted-runner/entrypoint.sh
+++ b/self-hosted-runner/entrypoint.sh
@@ -3,8 +3,12 @@
 # Detect architecture
 ARCH=$(uname -m)
 
+# Under QEMU emulation, setuid binaries (like sudo) do not work.
+# Run the GitHub Actions runner as root so that workflow steps
+# can install system packages without sudo.
 if [ "$ARCH" = "aarch64" ]; then
     echo "Architecture is aarch64 (ARM64). Applying QEMU workarounds..."
+    RUN_AS_ROOT=true
     mkdir -p /etc/docker
     cat <<EOF >/etc/docker/daemon.json
 {
@@ -12,14 +16,22 @@ if [ "$ARCH" = "aarch64" ]; then
   "ip6tables": false
 }
 EOF
+else
+    RUN_AS_ROOT=false
 fi
 
 # Start docker daemon
 service docker start
 
+if [ "$RUN_AS_ROOT" = "true" ]; then
+    RUN_PREFIX=""
+else
+    RUN_PREFIX="runuser -u ubuntu --"
+fi
+
 if [ -n "$PERSONAL_ACCESS_TOKEN" ]; then
     echo "Using personal access token"
-    runuser -u ubuntu -- ./config.sh \
+    $RUN_PREFIX ./config.sh \
         --unattended \
         --url $REPOSITORY_URL \
         --pat "$PERSONAL_ACCESS_TOKEN" \
@@ -30,7 +42,7 @@ if [ -n "$PERSONAL_ACCESS_TOKEN" ]; then
         --replace
 else
     echo "Using registry token"
-    runuser -u ubuntu -- ./config.sh \
+    $RUN_PREFIX ./config.sh \
         --unattended \
         --url $REPOSITORY_URL \
         --token "$REGISTRY_TOKEN" \
@@ -41,4 +53,4 @@ else
         --replace
 fi
 
-exec runuser -u ubuntu -- ./run.sh
+exec $RUN_PREFIX ./run.sh

--- a/self-hosted-runner/entrypoint.sh
+++ b/self-hosted-runner/entrypoint.sh
@@ -25,6 +25,7 @@ service docker start
 
 if [ "$RUN_AS_ROOT" = "true" ]; then
     RUN_PREFIX=""
+    export RUNNER_ALLOW_RUNASROOT=1
 else
     RUN_PREFIX="runuser -u ubuntu --"
 fi

--- a/self-hosted-runner/entrypoint.sh
+++ b/self-hosted-runner/entrypoint.sh
@@ -1,13 +1,24 @@
 #!/bin/bash
 
-# Start docker daemon
-service docker start
-
 # Detect architecture
 ARCH=$(uname -m)
 
+if [ "$ARCH" = "aarch64" ]; then
+    echo "Architecture is aarch64 (ARM64). Applying QEMU workarounds..."
+    mkdir -p /etc/docker
+    cat <<EOF >/etc/docker/daemon.json
+{
+  "iptables": false,
+  "ip6tables": false
+}
+EOF
+fi
+
+# Start docker daemon
+service docker start
+
 if [ -n "$PERSONAL_ACCESS_TOKEN" ]; then
-    echo "Using personal access token";
+    echo "Using personal access token"
     runuser -u ubuntu -- ./config.sh \
         --unattended \
         --url $REPOSITORY_URL \
@@ -16,9 +27,9 @@ if [ -n "$PERSONAL_ACCESS_TOKEN" ]; then
         --runnergroup $RUNNER_GROUP \
         --labels "${RUNNER_LABELS},${ARCH}" \
         --work /home/ubuntu/actions-runner \
-        --replace;
+        --replace
 else
-    echo "Using registry token";
+    echo "Using registry token"
     runuser -u ubuntu -- ./config.sh \
         --unattended \
         --url $REPOSITORY_URL \
@@ -27,7 +38,7 @@ else
         --runnergroup $RUNNER_GROUP \
         --labels "${RUNNER_LABELS},${ARCH}" \
         --work /home/ubuntu/actions-runner \
-        --replace;
+        --replace
 fi
 
 exec runuser -u ubuntu -- ./run.sh


### PR DESCRIPTION
## Summary
- Add new reusable workflow (`_build_linux_no_container.yml`) for building Flash Attention on self-hosted runners without containers
- Include post-build cleanup (flash-attention source, venv, pip/uv cache, CUDA) for self-hosted runners
- Upgrade `build-and-upload` composite action: setup-cuda to v1.3.0, add `--python-preference only-managed`
- Separate build execution and wheel location into distinct steps to prevent `$GITHUB_OUTPUT` file corruption during long-running builds

## Test plan
- [x] Triggered test-build workflow for `linux-arm64-no-container` platform (https://github.com/mjun0812/flash-attention-prebuild-wheels/actions/runs/23724951684)
- [ ] Verify build success and wheel location step completes without `$GITHUB_OUTPUT` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)