### PR TITLE
feat: add docs pagination and release fallback data

### DIFF
--- a/.github/workflows/update-docs-releases-json.yml
+++ b/.github/workflows/update-docs-releases-json.yml
@@ -1,0 +1,37 @@
+name: Update Docs Release Fallback JSON
+
+on:
+  schedule:
+    # Run daily at 01:00 UTC
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-docs-releases-json:
+    name: Update docs release fallback JSON
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Update docs release fallback JSON
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uv run --python 3.14 --script scripts/maintenance/update_docs_releases_json.py
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/data/releases.json
+          git diff --staged --quiet || git commit -m "chore: update docs releases fallback data
+
+          Refresh hosted release JSON for the docs search page on $(date -u +%Y-%m-%d)."
+          git push

--- a/docs/index.html
+++ b/docs/index.html
@@ -181,6 +181,34 @@
             overflow-x: auto;
         }
 
+        .pagination {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            margin-top: 16px;
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        .pagination-controls {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .pagination-status {
+            min-width: 96px;
+            text-align: center;
+            font-weight: 500;
+            color: var(--text-color);
+        }
+
+        .pagination .btn:disabled {
+            cursor: not-allowed;
+            opacity: 0.5;
+        }
+
         table {
             width: 100%;
             border-collapse: collapse;
@@ -391,6 +419,15 @@
                 flex: 1;
             }
 
+            .pagination {
+                align-items: stretch;
+                flex-direction: column;
+            }
+
+            .pagination-controls {
+                justify-content: space-between;
+            }
+
             th, td {
                 padding: 8px 12px;
             }
@@ -511,6 +548,14 @@
                 <div id="empty-state" class="empty-state" style="display: none;">
                     No wheels match your filters. Try adjusting your selection.
                 </div>
+                <div id="pagination" class="pagination" style="display: none;">
+                    <span id="pagination-range">0-0 of 0</span>
+                    <div class="pagination-controls">
+                        <button class="btn btn-secondary" id="prev-page-btn">Previous</button>
+                        <span class="pagination-status" id="pagination-status">Page 1 of 1</span>
+                        <button class="btn btn-secondary" id="next-page-btn">Next</button>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -524,6 +569,7 @@
         const API_BASE = 'https://api.github.com';
         const CACHE_KEY = 'flash-attn-wheels-cache';
         const CACHE_DURATION = 60 * 60 * 1000; // 1 hour in milliseconds
+        const ITEMS_PER_PAGE = 50;
 
         // Wheel filename pattern (ported from common.py)
         // Supports both flash_attn and flash_attn_3, and both cpXXX/cpXXXt and abi3 tags
@@ -535,6 +581,7 @@
         let selectedWheel = null;
         let sortColumn = 'flash';
         let sortDirection = 'desc';
+        let currentPage = 1;
 
         // DOM Elements
         const elements = {
@@ -557,7 +604,12 @@
             commandDisplay: document.getElementById('command-display'),
             copyCommandBtn: document.getElementById('copy-command-btn'),
             copyUrlBtn: document.getElementById('copy-url-btn'),
-            cacheInfo: document.getElementById('cache-info')
+            cacheInfo: document.getElementById('cache-info'),
+            pagination: document.getElementById('pagination'),
+            paginationRange: document.getElementById('pagination-range'),
+            paginationStatus: document.getElementById('pagination-status'),
+            prevPageBtn: document.getElementById('prev-page-btn'),
+            nextPageBtn: document.getElementById('next-page-btn')
         };
 
         // Parse wheel filename (ported from common.py)
@@ -807,6 +859,9 @@
 
         // Apply filters to wheels
         function applyFilters() {
+            currentPage = 1;
+            selectedWheel = null;
+
             const filters = {
                 package: elements.packageFilter.value,
                 flash: elements.flashFilter.value,
@@ -858,21 +913,57 @@
             });
         }
 
+        // Get total page count for the filtered result set
+        function getTotalPages() {
+            return Math.max(1, Math.ceil(filteredWheels.length / ITEMS_PER_PAGE));
+        }
+
+        // Keep the current page in range after filtering or sorting
+        function clampCurrentPage() {
+            currentPage = Math.min(Math.max(currentPage, 1), getTotalPages());
+        }
+
+        // Render pagination controls
+        function renderPagination(pageStart, pageEnd) {
+            if (filteredWheels.length <= ITEMS_PER_PAGE) {
+                elements.pagination.style.display = 'none';
+                return;
+            }
+
+            const totalPages = getTotalPages();
+            elements.pagination.style.display = 'flex';
+            elements.paginationRange.textContent = `${pageStart + 1}-${pageEnd} of ${filteredWheels.length}`;
+            elements.paginationStatus.textContent = `Page ${currentPage} of ${totalPages}`;
+            elements.prevPageBtn.disabled = currentPage === 1;
+            elements.nextPageBtn.disabled = currentPage === totalPages;
+        }
+
         // Render the table
         function renderTable() {
+            clampCurrentPage();
             elements.count.textContent = filteredWheels.length;
 
             if (filteredWheels.length === 0) {
                 elements.wheelsTable.innerHTML = '';
                 elements.emptyState.style.display = 'block';
                 elements.commandSection.style.display = 'none';
+                elements.pagination.style.display = 'none';
                 return;
             }
 
             elements.emptyState.style.display = 'none';
+            if (selectedWheel === null) {
+                elements.commandSection.style.display = 'none';
+            }
 
-            const html = filteredWheels.map((wheel, index) => `
-                <tr data-index="${index}" class="${selectedWheel === index ? 'selected' : ''}">
+            const pageStart = (currentPage - 1) * ITEMS_PER_PAGE;
+            const pageEnd = Math.min(pageStart + ITEMS_PER_PAGE, filteredWheels.length);
+            const visibleWheels = filteredWheels.slice(pageStart, pageEnd);
+
+            const html = visibleWheels.map((wheel, pageIndex) => {
+                const index = pageStart + pageIndex;
+                return `
+                <tr data-index="${index}" class="${selectedWheel === wheel ? 'selected' : ''}">
                     <td>${wheel.packageName === 'flash_attn_3' ? 'FA3' : 'FA2'}</td>
                     <td>${wheel.platform}</td>
                     <td>${wheel.flashVersion}</td>
@@ -898,9 +989,11 @@
                         </button>
                     </td>
                 </tr>
-            `).join('');
+            `;
+            }).join('');
 
             elements.wheelsTable.innerHTML = html;
+            renderPagination(pageStart, pageEnd);
 
             // Add click listeners to rows
             for (const row of elements.wheelsTable.querySelectorAll('tr')) {
@@ -929,12 +1022,12 @@
 
         // Select a wheel and show install command
         function selectWheel(index) {
-            selectedWheel = index;
             const wheel = filteredWheels[index];
+            selectedWheel = wheel;
 
             // Update selected row style
-            elements.wheelsTable.querySelectorAll('tr').forEach((row, i) => {
-                row.classList.toggle('selected', i === index);
+            elements.wheelsTable.querySelectorAll('tr').forEach(row => {
+                row.classList.toggle('selected', parseInt(row.dataset.index, 10) === index);
             });
 
             // Show command section
@@ -1062,18 +1155,31 @@
             });
         });
 
+        // Pagination handlers
+        elements.prevPageBtn.addEventListener('click', () => {
+            if (currentPage > 1) {
+                currentPage--;
+                renderTable();
+            }
+        });
+
+        elements.nextPageBtn.addEventListener('click', () => {
+            if (currentPage < getTotalPages()) {
+                currentPage++;
+                renderTable();
+            }
+        });
+
         // Copy button handlers
         elements.copyCommandBtn.addEventListener('click', () => {
             if (selectedWheel !== null) {
-                const wheel = filteredWheels[selectedWheel];
-                copyToClipboard(`pip install ${decodeURIComponent(wheel.url)}`, elements.copyCommandBtn);
+                copyToClipboard(`pip install ${decodeURIComponent(selectedWheel.url)}`, elements.copyCommandBtn);
             }
         });
 
         elements.copyUrlBtn.addEventListener('click', () => {
             if (selectedWheel !== null) {
-                const wheel = filteredWheels[selectedWheel];
-                copyToClipboard(decodeURIComponent(wheel.url), elements.copyUrlBtn);
+                copyToClipboard(decodeURIComponent(selectedWheel.url), elements.copyUrlBtn);
             }
         });
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -569,6 +569,7 @@
         const API_BASE = 'https://api.github.com';
         const CACHE_KEY = 'flash-attn-wheels-cache';
         const CACHE_DURATION = 60 * 60 * 1000; // 1 hour in milliseconds
+        const FALLBACK_RELEASES_URL = 'data/releases.json';
         const ITEMS_PER_PAGE = 50;
 
         // Wheel filename pattern (ported from common.py)
@@ -720,6 +721,25 @@
             return releases;
         }
 
+        // Fetch hosted fallback release data
+        async function fetchHostedReleases() {
+            const response = await fetch(FALLBACK_RELEASES_URL, { cache: 'no-cache' });
+            if (!response.ok) {
+                throw new Error(`Hosted fallback error: ${response.status} ${response.statusText}`);
+            }
+
+            const payload = await response.json();
+            const releases = Array.isArray(payload) ? payload : payload.releases;
+            if (!Array.isArray(releases)) {
+                throw new Error('Hosted fallback JSON does not contain a releases array');
+            }
+
+            return {
+                generatedAt: Array.isArray(payload) ? null : payload.generatedAt,
+                releases
+            };
+        }
+
         // Extract wheels from releases
         function extractWheels(releases) {
             const wheels = [];
@@ -758,6 +778,17 @@
             return Array.from(seen.values());
         }
 
+        // Build the searchable wheel list from release data
+        function buildWheelData(releases) {
+            const wheels = extractWheels(releases);
+            return deduplicateWheels(wheels);
+        }
+
+        // Format a timestamp for display
+        function formatTimestamp(timestamp) {
+            return new Date(timestamp).toLocaleString();
+        }
+
         // Load data with caching
         async function loadData(forceRefresh = false) {
             // Check cache
@@ -765,9 +796,9 @@
                 const cached = localStorage.getItem(CACHE_KEY);
                 if (cached) {
                     try {
-                        const { data, timestamp } = JSON.parse(cached);
+                        const { data, timestamp, source, fallbackGeneratedAt } = JSON.parse(cached);
                         if (Date.now() - timestamp < CACHE_DURATION) {
-                            updateCacheInfo(timestamp);
+                            updateCacheInfo(timestamp, source || 'local cache', fallbackGeneratedAt);
                             return data;
                         }
                     } catch (e) {
@@ -777,25 +808,47 @@
             }
 
             // Fetch fresh data
-            const releases = await fetchReleases();
-            const wheels = extractWheels(releases);
-            const deduplicated = deduplicateWheels(wheels);
+            let deduplicated;
+            let source = 'GitHub API';
+            let fallbackGeneratedAt = null;
+
+            try {
+                const releases = await fetchReleases();
+                deduplicated = buildWheelData(releases);
+            } catch (apiError) {
+                console.warn('GitHub API failed. Falling back to hosted release JSON:', apiError);
+                try {
+                    const fallback = await fetchHostedReleases();
+                    deduplicated = buildWheelData(fallback.releases);
+                    source = 'hosted fallback JSON';
+                    fallbackGeneratedAt = fallback.generatedAt;
+                } catch (fallbackError) {
+                    throw new Error(
+                        `GitHub API failed (${apiError.message}); hosted fallback failed (${fallbackError.message})`
+                    );
+                }
+            }
 
             // Save to cache
             const cacheData = {
                 data: deduplicated,
-                timestamp: Date.now()
+                timestamp: Date.now(),
+                source,
+                fallbackGeneratedAt
             };
             localStorage.setItem(CACHE_KEY, JSON.stringify(cacheData));
-            updateCacheInfo(cacheData.timestamp);
+            updateCacheInfo(cacheData.timestamp, source, fallbackGeneratedAt);
 
             return deduplicated;
         }
 
         // Update cache info display
-        function updateCacheInfo(timestamp) {
-            const date = new Date(timestamp);
-            elements.cacheInfo.textContent = `Data cached at ${date.toLocaleString()}`;
+        function updateCacheInfo(timestamp, source = 'local cache', fallbackGeneratedAt = null) {
+            let info = `Data cached at ${formatTimestamp(timestamp)} from ${source}`;
+            if (fallbackGeneratedAt) {
+                info += ` (fallback generated at ${formatTimestamp(fallbackGeneratedAt)})`;
+            }
+            elements.cacheInfo.textContent = info;
         }
 
         // Package display name mapping

--- a/scripts/maintenance/update_docs_releases_json.py
+++ b/scripts/maintenance/update_docs_releases_json.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "requests",
+# ]
+# ///
+
+"""Update hosted GitHub release data for the docs search page."""
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+import requests
+
+DEFAULT_REPO = "mjun0812/flash-attention-prebuild-wheels"
+DEFAULT_OUTPUT = "docs/data/releases.json"
+API_BASE = "https://api.github.com"
+
+
+def get_github_token() -> str | None:
+    """Get the GitHub token from the environment."""
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print(
+            "Warning: GITHUB_TOKEN is not set. API rate limit will be restricted.",
+            file=sys.stderr,
+        )
+    return token
+
+
+def build_headers(token: str | None) -> dict[str, str]:
+    """Build headers for GitHub API requests.
+
+    Args:
+        token: Optional GitHub token.
+
+    Returns:
+        Headers to send with GitHub API requests.
+    """
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_all_releases(repo: str, token: str | None) -> list[dict[str, Any]]:
+    """Fetch all releases from GitHub.
+
+    Args:
+        repo: Repository in owner/name format.
+        token: Optional GitHub token.
+
+    Returns:
+        GitHub release objects returned by the releases API.
+
+    Raises:
+        requests.HTTPError: Raised when GitHub returns an error response.
+    """
+    headers = build_headers(token)
+    releases: list[dict[str, Any]] = []
+    page = 1
+    per_page = 100
+
+    while True:
+        url = f"{API_BASE}/repos/{repo}/releases"
+        params = {"page": page, "per_page": per_page}
+        print(f"Fetching releases page {page}...", file=sys.stderr)
+        response = requests.get(url, headers=headers, params=params, timeout=30)
+        response.raise_for_status()
+
+        page_releases = response.json()
+        if not page_releases:
+            break
+
+        releases.extend(page_releases)
+        print(f"  Found {len(page_releases)} releases", file=sys.stderr)
+
+        if len(page_releases) < per_page:
+            break
+
+        page += 1
+        time.sleep(0.5)
+
+    return releases
+
+
+def count_assets(releases: list[dict[str, Any]]) -> int:
+    """Count release assets in the release payload.
+
+    Args:
+        releases: GitHub release objects.
+
+    Returns:
+        Total number of assets across releases.
+    """
+    return sum(len(release.get("assets", [])) for release in releases)
+
+
+def write_releases_json(
+    output_path: Path,
+    repo: str,
+    releases: list[dict[str, Any]],
+) -> None:
+    """Write release data as hosted docs JSON.
+
+    Args:
+        output_path: JSON file path.
+        repo: Repository in owner/name format.
+        releases: GitHub release objects.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "repository": repo,
+        "releaseCount": len(releases),
+        "assetCount": count_assets(releases),
+        "releases": releases,
+    }
+
+    with NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=output_path.parent,
+        delete=False,
+    ) as temp_file:
+        json.dump(payload, temp_file, indent=2, ensure_ascii=False)
+        temp_file.write("\n")
+        temp_path = Path(temp_file.name)
+
+    temp_path.replace(output_path)
+    print(
+        f"Saved {len(releases)} releases and {payload['assetCount']} assets to {output_path}",
+        file=sys.stderr,
+    )
+
+
+def main() -> None:
+    """Run the docs release JSON update command."""
+    parser = argparse.ArgumentParser(
+        description="Update hosted GitHub release data for the docs search page"
+    )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help=f"GitHub repository (default: {DEFAULT_REPO})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(DEFAULT_OUTPUT),
+        help=f"Output JSON path (default: {DEFAULT_OUTPUT})",
+    )
+    args = parser.parse_args()
+
+    token = get_github_token()
+    releases = fetch_all_releases(args.repo, token)
+    if not releases:
+        raise RuntimeError("No releases were fetched. Refusing to write fallback JSON.")
+
+    write_releases_json(args.output, args.repo, releases)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Overview and Background

This PR improves the GitHub Pages search page resilience and usability. The page now paginates large wheel result sets and can fall back to hosted release JSON when direct browser calls to the GitHub API fail because of rate limits or availability issues.

## Related Issues

Related to #96

## Changes

- Add client-side pagination with 50 wheel rows per page.
- Keep filtering, sorting, row selection, and copy actions working across paginated rows.
- Add hosted release data at `docs/data/releases.json` for API fallback.
- Add a maintenance script to refresh the hosted release JSON from GitHub Releases.
- Add a scheduled GitHub Actions workflow to update and commit the fallback JSON daily.

## Test Instructions

- `uvx ruff format scripts/maintenance/update_docs_releases_json.py`
- `uvx ruff check --fix scripts/maintenance/update_docs_releases_json.py`
- `uvx --with requests ty check scripts/maintenance/update_docs_releases_json.py`
- `uv run --python 3.14 --script scripts/maintenance/update_docs_releases_json.py`
- `jq` validation for `docs/data/releases.json` release and asset counts.
- Browser verified normal GitHub API loading, API failure fallback loading, fallback filtering, and the double-failure error state.
