### PR TITLE
fix(build/windows): enable MSVC /Zc:preprocessor for CUDA 13.2+

### DIFF
--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -178,6 +178,23 @@ function Test-Cuda13OrNewer {
     }
 }
 
+function Test-Cuda132OrNewer {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Version
+    )
+
+    # CUDA 13.2 bundles a CCCL header (cuda/std/__cccl/preprocessor.h) that
+    # raises `#error C1189` when MSVC's traditional preprocessor is in use,
+    # so we need to enable /Zc:preprocessor for 13.2 and newer toolkits.
+    try {
+        return ([Version]$Version -ge [Version]"13.2")
+    } catch {
+        Write-Warning "Could not parse CUDA version '$Version' for /Zc:preprocessor check. Skipping CUDA 13.2+ workaround."
+        return $false
+    }
+}
+
 function Apply-GitPatch {
     param(
         [Parameter(Mandatory=$true)]
@@ -376,6 +393,20 @@ $env:FLASH_ATTENTION_FORCE_BUILD = "TRUE"
 $env:NVCC_FLAGS = "-w --disable-warnings"
 $env:CXXFLAGS = "/w"
 $env:CFLAGS = "/w"
+# CUDA 13.2+ ships a CCCL header that emits `#error C1189` when MSVC's
+# traditional preprocessor is in use. Force the standard-conforming
+# preprocessor for both host cl.exe and nvcc-driven cl.exe invocations.
+if (Test-Cuda132OrNewer -Version $CudaVersion) {
+    Write-Host "Enabling MSVC standard-conforming preprocessor (/Zc:preprocessor) for CUDA 13.2+"
+    $env:CXXFLAGS = "$env:CXXFLAGS /Zc:preprocessor"
+    $env:CFLAGS = "$env:CFLAGS /Zc:preprocessor"
+    $nvccZcFlag = '-Xcompiler="/Zc:preprocessor"'
+    if ($env:NVCC_APPEND_FLAGS) {
+        $env:NVCC_APPEND_FLAGS = "$env:NVCC_APPEND_FLAGS $nvccZcFlag"
+    } else {
+        $env:NVCC_APPEND_FLAGS = $nvccZcFlag
+    }
+}
 # Avoid verbose dependency-generation output from nvcc on Windows builds.
 $env:TORCH_EXTENSION_SKIP_NVCC_GEN_DEPENDENCIES = "1"
 # Suppress ninja verbose output


### PR DESCRIPTION
## Summary

Fix Windows self-hosted CI failures for all builds targeting **CUDA 13.2** by switching MSVC to the standard-conforming preprocessor.

## Background

In the v0.9.23 build run, every Windows self-hosted job that targets CUDA 13.2 fails during the first batch of nvcc compilations, regardless of Python or flash-attention version:

| flash-attn | python | cuda | result |
|---|---|---|---|
| 2.8.3 | 3.10  | 13.2 | ❌ |
| 2.8.3 | 3.12  | 13.2 | ❌ |
| 2.8.3 | 3.13  | 13.2 | ❌ |
| 2.8.3 | 3.13t | 13.2 | ❌ |
| fa3   | 3.12  | 13.2 | ❌ |

The same combinations on CUDA 13.0 / 12.6 succeed. The compiler emits:

```
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\bin\..\include\cccl\cuda\std\__cccl\preprocessor.h(23):
fatal error C1189: #error: MSVC/cl.exe with traditional preprocessor is used.
Please switch to the standard conforming preprocessor by passing `/Zc:preprocessor` to cl.exe.
```

CUDA 13.2 ships an updated CCCL header that hard-errors when MSVC's traditional preprocessor is in use. CUDA 13.0 still allows it.

## Changes

- Add `Test-Cuda132OrNewer` helper alongside the existing `Test-Cuda13OrNewer`.
- When the target CUDA toolkit is 13.2 or newer, before invoking `setup.py bdist_wheel`:
  - Append `/Zc:preprocessor` to `$env:CXXFLAGS` and `$env:CFLAGS` (covers direct `cl.exe` invocations from the C++ extension build).
  - Append `-Xcompiler="/Zc:preprocessor"` to `$env:NVCC_APPEND_FLAGS` (covers `nvcc` -> `cl.exe` invocations for `.cu` files).

CUDA 13.0 / 12.x paths are intentionally left untouched: those toolkits' CCCL only emits a warning (not `#error`) for the traditional preprocessor, and the existing builds for those CUDA versions are green.

## Scope notes

This PR addresses only the CUDA 13.2 failure cluster. The Python 3.14 / 3.14t failures observed in the same run (`LNK1104: python314.lib`) have a different root cause (uv distribution selection + cleanup) and will be addressed in a separate PR.

## Verification

Manual verification by the maintainer (no automated test-build).

🤖 Generated with Claude Code
