### PR TITLE
fix(ci/windows): pin uv Python identifier and clean Roaming uv dir on self-hosted runner

### DIFF
--- a/.github/workflows/_build_windows_self_host.yml
+++ b/.github/workflows/_build_windows_self_host.yml
@@ -76,7 +76,23 @@ jobs:
       - name: Install Python
         shell: pwsh
         run: |
-          uv venv -p ${{ inputs.python-version }}
+          # Pin the uv Python identifier explicitly. A bare `-p 3.14` lets uv
+          # pick up an already-installed "cpython-3.14+freethreaded" distribution
+          # left over from a previous job on the same self-hosted runner, which
+          # then causes setuptools to link against the wrong python lib
+          # (LNK1104: python314.lib). Resolving the full identifier from the
+          # matrix value ("3.14" -> non-FT, "3.14t" -> freethreaded) avoids the
+          # ambiguity.
+          $pyver = "${{ inputs.python-version }}"
+          if ($pyver.EndsWith('t')) {
+            $base = $pyver.TrimEnd('t')
+            $pyIdentifier = "cpython-$base+freethreaded-windows-x86_64-none"
+          } else {
+            $pyIdentifier = "cpython-$pyver-windows-x86_64-none"
+          }
+          Write-Host "Resolved uv Python identifier: $pyIdentifier"
+          uv python install $pyIdentifier
+          uv venv --python-preference only-managed -p $pyIdentifier
           uv pip install -U pip setuptools==75.8.0 wheel packaging psutil numpy ninja
           $current_dir = (Get-Location).Path
           echo "$current_dir\.venv\Scripts" >> $env:GITHUB_PATH
@@ -203,13 +219,28 @@ jobs:
             Write-Host "[3/6] pip cache not found, skipping"
           }
 
-          # 4. Remove uv cache
-          $uvCacheDir = Join-Path $env:LOCALAPPDATA "uv"
-          if (Test-Path $uvCacheDir) {
-            Write-Host "[4/6] Removing uv cache: $uvCacheDir"
-            Remove-Item -Path $uvCacheDir -Recurse -Force -ErrorAction SilentlyContinue
-          } else {
-            Write-Host "[4/6] uv cache not found, skipping"
+          # 4. Remove uv cache *and* managed Python installs.
+          # uv keeps its cache under %LOCALAPPDATA%\uv but the managed Python
+          # distributions (cpython-3.X[+freethreaded]-windows-x86_64-none) live
+          # under %APPDATA%\uv\python (Roaming). Without wiping the Roaming
+          # tree, a previous job's freethreaded 3.14 install lingers and the
+          # next `uv venv -p 3.14` resolves to it, producing LNK1104 against
+          # python314.lib.
+          $uvPaths = @(
+            (Join-Path $env:LOCALAPPDATA "uv"),
+            (Join-Path $env:APPDATA "uv\python"),
+            (Join-Path $env:APPDATA "uv\tools")
+          )
+          $anyRemoved = $false
+          foreach ($p in $uvPaths) {
+            if (Test-Path $p) {
+              Write-Host "[4/6] Removing uv path: $p"
+              Remove-Item -Path $p -Recurse -Force -ErrorAction SilentlyContinue
+              $anyRemoved = $true
+            }
+          }
+          if (-not $anyRemoved) {
+            Write-Host "[4/6] uv paths not found, skipping"
           }
 
           # 5. Uninstall CUDA using proper Windows uninstaller


### PR DESCRIPTION
## Summary

Fix Windows self-hosted CI failures for **Python 3.14 / 3.14t** builds, caused by uv picking up a stale freethreaded Python distribution left over from a previous job.

## Background

In the v0.9.23 build run, every Windows self-hosted job that targets Python 3.14 or 3.14t fails the link step:

| flash-attn | python  | cuda | result |
|---|---|---|---|
| 2.8.3 | 3.14  | 13.0 | ❌ |
| 2.8.3 | 3.14t | 13.0 | ❌ |
| 2.8.3 | 3.14t | 12.6 | ❌ |
| fa3   | 3.14  | 13.0 | ❌ |

All fail with:

```
LINK : fatal error LNK1104: cannot open file 'python314.lib'
```

### Root cause

Comparing logs for a successful 3.13 job and a failing 3.14 job:

```
# success (3.13):
uv venv -p 3.13     -> Using CPython 3.13.12

# failure (3.14):
uv venv -p 3.14     -> Using CPython 3.14.4+freethreaded   (!!)
```

Even though the matrix passes `python-version: 3.14` (non-FT), uv resolves it to the freethreaded distribution. setuptools then writes build artifacts under `build\temp.win-amd64-cpython-314t` and the linker asks for `python314.lib`, while the freethreaded distribution ships only `python314t.lib` → `LNK1104`.

The reason uv keeps picking the freethreaded build is twofold:

1. The cleanup step at the end of each job only deletes `%LOCALAPPDATA%\uv` (cache). uv's actual managed Python distributions live under `%APPDATA%\uv\python` (Roaming), e.g. `C:\Users\<user>\AppData\Roaming\uv\python\cpython-3.14+freethreaded-windows-x86_64-none\`. That tree is never wiped, so a previously installed 3.14 freethreaded interpreter persists across jobs.

2. `uv venv -p 3.14` is then free to satisfy the request from the leftover freethreaded install.

## Changes

`.github/workflows/_build_windows_self_host.yml`:

### `Install Python` step

Pin the uv Python identifier explicitly from the matrix value:

| `inputs.python-version` | identifier |
|---|---|
| `3.14`  | `cpython-3.14-windows-x86_64-none` |
| `3.14t` | `cpython-3.14+freethreaded-windows-x86_64-none` |
| `3.13`  | `cpython-3.13-windows-x86_64-none` |
| ... | ... |

Also pass `--python-preference only-managed` so uv never falls back to a system Python, and run `uv python install $id` beforehand to make the resolution deterministic.

### `Cleanup (always run)` step

Extend the uv-cache removal to delete:

- `%LOCALAPPDATA%\uv` (cache, existing)
- `%APPDATA%\uv\python` (managed Python distributions, **new** — this is the one that was leaking)
- `%APPDATA%\uv\tools` (uv tool installs, new)

so each job starts from a clean uv state on the self-hosted runner.

## Notes on 3.14t

There is a follow-up uncertainty: even with the correct freethreaded distribution selected, PyTorch 2.12.0's `cpp_extension` / setuptools may still link against `python314.lib` (non-FT) when building for 3.14t, which would reproduce LNK1104. 3.13t builds currently succeed, so the path probably works, but if 3.14t still fails after this PR, the next step is to either patch the link flag for free-threaded Python or temporarily exclude `3.14t × torch 2.12.0` in `coverage_matrix.py`. Decision deferred until we see the re-run.

## Scope notes

This PR only addresses the Python 3.14 / 3.14t failure cluster. The CUDA 13.2 cluster is fixed by #100.

## Verification

Manual verification by the maintainer (no automated test-build).

🤖 Generated with Claude Code
