### PR TITLE
fix(matrix/windows): exclude Python 3.14t × torch 2.12.0 on Windows

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -285,7 +285,10 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         "3.13",
         "3.14",
         "3.13t",
-        "3.14t",
+        # "3.14t",  # Excluded: torch 2.12.0's setuptools/cpp_extension cannot
+        # resolve the free-threaded import library on Windows
+        # (LNK1104: python314.lib vs python314t.lib). Re-enable once PyTorch
+        # / setuptools handle this for free-threaded CPython on Windows.
     ],
     "torch-version": [
         # "2.5.1",

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -194,9 +194,16 @@ LINUX_ARM64_MATRIX = {
     "cuda-version": ["12.6", "12.8", "12.9", "13.0", "13.2"],
 }
 
+# Windows excludes "3.14t" because torch 2.12.0's setuptools/cpp_extension
+# cannot resolve the free-threaded import library on Windows
+# (LNK1104: python314.lib vs python314t.lib).
+# Note: "3.13t" continues to work because that distribution is shipped under a
+# different uv identifier and the resulting link name resolves correctly.
+WINDOWS_PYTHON_VERSIONS = [*PYTHON_VERSIONS, "3.13t"]
+
 WINDOWS_MATRIX = {
     "flash-attn-version": ["2.8.3", FA3_STABLE_COMMIT],
-    "python-version": ALL_PYTHON_VERSIONS,
+    "python-version": WINDOWS_PYTHON_VERSIONS,
     "torch-version": [
         "2.9.1",
         "2.10.0",


### PR DESCRIPTION
## Summary

Drop **Python 3.14t (free-threaded) × torch 2.12.0** from the Windows build matrix and the Windows coverage matrix until PyTorch / setuptools resolves the free-threaded import-library lookup on Windows.

## Background

In the v0.9.25 build (currently mid-run, see [#26454876844](https://github.com/mjun0812/flash-attention-prebuild-wheels/actions/runs/26454876844)) the Windows self-hosted jobs that fixed #100 (CUDA 13.2 `/Zc:preprocessor`) and #101 (uv distribution selection) are now passing for every combination — except 3.14t:

```
Build Windows (self-hosted) (2.8.3, 3.14t, 2.12.0, 13.0) → failure
LINK : fatal error LNK1104: cannot open file 'python314.lib'
```

With #101 the runner now correctly picks `cpython-3.14+freethreaded-windows-x86_64-none`, but PyTorch 2.12.0's `cpp_extension` / setuptools still asks the linker for `python314.lib` while the free-threaded distribution only ships `python314t.lib`. There is no flash-attention-side fix for this; it is an upstream concern.

Interesting contrast: 3.13t works on Windows in the same run. The 3.13 free-threaded distribution is shipped under a different uv identifier (`cpython-3.13t-windows-x86_64-none`) and the resulting link name happens to resolve correctly. The 3.14 free-threaded layout (`cpython-3.14+freethreaded-…`) does not.

## Changes

### `create_matrix.py`
Comment out `"3.14t"` from `WINDOWS_SELF_HOSTED_MATRIX["python-version"]`. The build matrix will no longer schedule the failing Windows jobs.

```diff
     "python-version": [
         "3.10",
         "3.11",
         "3.12",
         "3.13",
         "3.14",
         "3.13t",
-        "3.14t",
+        # "3.14t",  # Excluded: torch 2.12.0's setuptools/cpp_extension cannot
+        # resolve the free-threaded import library on Windows
+        # (LNK1104: python314.lib vs python314t.lib). Re-enable once PyTorch
+        # / setuptools handle this for free-threaded CPython on Windows.
     ],
```

### `scripts/coverage_matrix.py`
Replace `ALL_PYTHON_VERSIONS` with a new `WINDOWS_PYTHON_VERSIONS = [*PYTHON_VERSIONS, "3.13t"]` (no `3.14t`) for `WINDOWS_MATRIX` so the coverage tables stop counting Windows × 3.14t as missing wheels.

```diff
+# Windows excludes "3.14t" because torch 2.12.0's setuptools/cpp_extension
+# cannot resolve the free-threaded import library on Windows
+# (LNK1104: python314.lib vs python314t.lib).
+# Note: "3.13t" continues to work because that distribution is shipped under a
+# different uv identifier and the resulting link name resolves correctly.
+WINDOWS_PYTHON_VERSIONS = [*PYTHON_VERSIONS, "3.13t"]
+
 WINDOWS_MATRIX = {
     "flash-attn-version": ["2.8.3", FA3_STABLE_COMMIT],
-    "python-version": ALL_PYTHON_VERSIONS,
+    "python-version": WINDOWS_PYTHON_VERSIONS,
     ...
 }
```

### Linux matrices: intentionally untouched

`LINUX_MATRIX` and `LINUX_ARM64_MATRIX` keep `ALL_PYTHON_VERSIONS` because the link-name issue is Windows-specific (Linux builds a `.so` and does not need the Python import library).

## Effect on the in-flight v0.9.25 run

This PR only affects future build matrices. The currently-running v0.9.25 still has 2 queued Windows × 3.14t jobs that will fail with the same LNK1104. They have to be left to fail (or the entire run cancelled, which would also stop the in-progress good builds) — not worth the cost of cancellation.

## Future re-enabling

Re-enable when:
1. PyTorch / setuptools picks `python314t.lib` for free-threaded `cpython-3.14+freethreaded` distributions on Windows; or
2. We patch `setup.py` to override the link name for free-threaded builds.

🤖 Generated with Claude Code
