### PR TITLE
chore(matrix/windows): scope to 3.13t torch 2.9-2.11 holes for fill-in step 2/3

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -274,10 +274,9 @@ WINDOWS_CODEBUILD_MATRIX = {
 }
 
 # Temporary matrix to fill missing Windows wheels.
-# Step 1 of 3 (Group 1): covers 12 combinations, of which 8 are missing
-# (3.10/3.11/3.12/3.14 × torch 2.12.0 × cuda 12.6/13.0/13.2 holes left over
-# from the v0.9.25 cancelled jobs). The other 4 jobs are existing wheels
-# that will be rebuilt and uploaded via --clobber.
+# Step 2 of 3 (Group 2): covers 9 combinations, all of which are missing
+# free-threaded 3.13t wheels for torch 2.9.1/2.10.0/2.11.0 (Group 1 already
+# backfilled the torch 2.12.0 holes in v0.9.26).
 # Restore the original (full) matrix after the missing-wheel rounds are done.
 WINDOWS_SELF_HOSTED_MATRIX = {
     "flash-attn-version": [
@@ -285,12 +284,12 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         # FA3_COMMIT,  # FA3 has no missing wheels; skipped during fill-in rounds.
     ],
     "python-version": [
-        "3.10",
-        "3.11",
-        "3.12",
-        # "3.13",   # No missing in Group 1
-        "3.14",
-        # "3.13t",  # No missing in Group 1
+        # "3.10",   # No missing in Group 2
+        # "3.11",   # No missing in Group 2
+        # "3.12",   # Group 3
+        # "3.13",   # No missing
+        # "3.14",   # Group 3
+        "3.13t",
         # "3.14t",  # Excluded entirely; see PR #102.
     ],
     "torch-version": [
@@ -298,18 +297,18 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         # "2.6.0",
         # "2.7.1",
         # "2.8.0",
-        # "2.9.1",
-        # "2.10.0",
-        # "2.11.0",
-        "2.12.0",
+        "2.9.1",
+        "2.10.0",
+        "2.11.0",
+        # "2.12.0",  # Already covered for 3.13t (existing)
     ],
     "cuda-version": [
         # "12.4",
         "12.6",
-        # "12.8",   # No missing in Group 1
+        "12.8",
         # "12.9",
         "13.0",
-        "13.2",
+        # "13.2",  # No missing in Group 2 (torch 2.9-2.11 don't support 13.2)
     ],
 }
 


### PR DESCRIPTION
## Summary

Step **2/3** of the Windows missing-wheel backfill (strategy Y: 3-tag split).

Temporarily scopes `WINDOWS_SELF_HOSTED_MATRIX` to **Group 2** — the 9 missing free-threaded (`3.13t`) wheels for torch 2.9.1 / 2.10.0 / 2.11.0.

## Progress so far

| | missing | coverage |
|---|---|---|
| before Group 1 | 21 | 84.1% |
| after Group 1 (v0.9.26) | 13 | 90.2% |
| **target after Group 2** | **4** | **~97%** |

## Group 2 matrix

| Field | Values |
|---|---|
| `flash-attn-version` | `2.8.3` |
| `python-version`     | `3.13t` |
| `torch-version`      | `2.9.1`, `2.10.0`, `2.11.0` |
| `cuda-version`       | `12.6`, `12.8`, `13.0` |

Cross product = **9 jobs**, all of which are **missing** (no rebuilds):

```
2.8.3  3.13t  2.9.1   12.6 / 12.8 / 13.0
2.8.3  3.13t  2.10.0  12.6 / 12.8 / 13.0
2.8.3  3.13t  2.11.0  12.6 / 12.8 / 13.0
```

- torch 2.12.0 × 3.13t is already covered (existing), so it is omitted.
- CUDA 13.2 is omitted because torch 2.9–2.11 do not support it (`TORCH_SUPPORT_CUDA_VERSIONS`).

## Timing

9 jobs × ~90 min on the single DIVA runner ≈ **13.5 hours**, within the 24h queue cap. No rerun needed.

## Verification

A dry run of `create_matrix.py` confirmed exactly these 9 tuples and that they match the Group 2 entries reported by `check_missing_packages.py`.

## Out of scope (step 3)

- Group 3 — `3.12 × 2.9.1 × 13.0`, `3.14 × 2.9.1 × 12.6/12.8`, `3.14 × 2.10.0 × 12.8` (4 missing + rebuilds)

A restore PR will return the matrix to the regular full configuration after step 3 completes and `check_missing_packages.py` reports 0 missing on Windows.

## How to use

1. Merge this PR.
2. Push `v0.9.27` tag on the merge commit.
3. After the run completes, confirm `check_missing_packages.py --platform windows` reports 4 remaining (Group 3).
4. Proceed to step 3.

🤖 Generated with Claude Code
