### PR TITLE
chore(matrix/windows): scope to 3.12/3.14 torch 2.9-2.10 holes for fill-in step 3/3

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -274,22 +274,24 @@ WINDOWS_CODEBUILD_MATRIX = {
 }
 
 # Temporary matrix to fill missing Windows wheels.
-# Step 2 of 3 (Group 2): covers 9 combinations, all of which are missing
-# free-threaded 3.13t wheels for torch 2.9.1/2.10.0/2.11.0 (Group 1 already
-# backfilled the torch 2.12.0 holes in v0.9.26).
-# Restore the original (full) matrix after the missing-wheel rounds are done.
+# Step 3 of 3 (Group 3): covers 12 combinations, of which 4 are missing
+# (3.12 × 2.9.1 × 13.0; 3.14 × 2.9.1 × 12.6/12.8; 3.14 × 2.10.0 × 12.8).
+# Groups 1 and 2 already backfilled the torch 2.12.0 and 3.13t holes.
+# The other 8 jobs are existing wheels that will be rebuilt and re-uploaded
+# via --clobber.
+# Restore the original (full) matrix after this final round completes.
 WINDOWS_SELF_HOSTED_MATRIX = {
     "flash-attn-version": [
         "2.8.3",
         # FA3_COMMIT,  # FA3 has no missing wheels; skipped during fill-in rounds.
     ],
     "python-version": [
-        # "3.10",   # No missing in Group 2
-        # "3.11",   # No missing in Group 2
-        # "3.12",   # Group 3
+        # "3.10",   # No missing
+        # "3.11",   # No missing
+        "3.12",
         # "3.13",   # No missing
-        # "3.14",   # Group 3
-        "3.13t",
+        "3.14",
+        # "3.13t",  # Covered by Group 2 (v0.9.27)
         # "3.14t",  # Excluded entirely; see PR #102.
     ],
     "torch-version": [
@@ -299,8 +301,8 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         # "2.8.0",
         "2.9.1",
         "2.10.0",
-        "2.11.0",
-        # "2.12.0",  # Already covered for 3.13t (existing)
+        # "2.11.0",  # No missing in Group 3
+        # "2.12.0",  # Covered by Group 1 (v0.9.26)
     ],
     "cuda-version": [
         # "12.4",
@@ -308,7 +310,7 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         "12.8",
         # "12.9",
         "13.0",
-        # "13.2",  # No missing in Group 2 (torch 2.9-2.11 don't support 13.2)
+        # "13.2",  # No missing in Group 3 (torch 2.9-2.10 don't support 13.2)
     ],
 }
 


### PR DESCRIPTION
## Summary

Step **3/3** (final) of the Windows missing-wheel backfill (strategy Y: 3-tag split).

Temporarily scopes `WINDOWS_SELF_HOSTED_MATRIX` to **Group 3** — the last 4 missing wheels for `3.12`/`3.14` × torch `2.9.1`/`2.10.0`.

## Progress so far

| | missing | coverage |
|---|---|---|
| before Group 1 | 21 | 84.1% |
| after Group 1 (v0.9.26) | 13 | 90.2% |
| after Group 2 (v0.9.27) | 4 | 97.0% |
| **target after Group 3** | **0** | **100%** |

## Group 3 matrix

| Field | Values |
|---|---|
| `flash-attn-version` | `2.8.3` |
| `python-version`     | `3.12`, `3.14` |
| `torch-version`      | `2.9.1`, `2.10.0` |
| `cuda-version`       | `12.6`, `12.8`, `13.0` |

Cross product = **12 jobs** = **4 missing + 8 rebuild**:

| python × torch × cuda | missing? |
|---|---|
| 3.12 × 2.9.1 × 13.0 | **missing** ✓ |
| 3.14 × 2.9.1 × 12.6 | **missing** ✓ |
| 3.14 × 2.9.1 × 12.8 | **missing** ✓ |
| 3.14 × 2.10.0 × 12.8 | **missing** ✓ |
| (other 8) | existing (rebuild via `--clobber`) |

CUDA 13.2 is omitted because torch 2.9–2.10 do not support it.

## Timing

12 jobs × ~90 min on the single DIVA runner ≈ **18 hours**, within the 24h queue cap. No rerun needed.

## Verification

A dry run of `create_matrix.py` confirmed exactly these 12 tuples and that all 4 `check_missing_packages.py` Group 3 entries are covered (`missing covered: 4/4`).

## Follow-up

After this round completes and `check_missing_packages.py --platform windows` reports **0 missing**, a separate PR will restore `WINDOWS_SELF_HOSTED_MATRIX` to the regular full configuration (all flash-attn versions / python versions / torch / cuda).

## How to use

1. Merge this PR.
2. Push `v0.9.28` tag on the merge commit.
3. After the run completes, confirm `check_missing_packages.py --platform windows` reports 0 missing.
4. Open the matrix-restore PR.

🤖 Generated with Claude Code
