### PR TITLE
chore(matrix/windows): restore full self-hosted matrix after backfill

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -273,44 +273,40 @@ WINDOWS_CODEBUILD_MATRIX = {
     ],
 }
 
-# Temporary matrix to fill missing Windows wheels.
-# Step 3 of 3 (Group 3): covers 12 combinations, of which 4 are missing
-# (3.12 × 2.9.1 × 13.0; 3.14 × 2.9.1 × 12.6/12.8; 3.14 × 2.10.0 × 12.8).
-# Groups 1 and 2 already backfilled the torch 2.12.0 and 3.13t holes.
-# The other 8 jobs are existing wheels that will be rebuilt and re-uploaded
-# via --clobber.
-# Restore the original (full) matrix after this final round completes.
 WINDOWS_SELF_HOSTED_MATRIX = {
     "flash-attn-version": [
         "2.8.3",
-        # FA3_COMMIT,  # FA3 has no missing wheels; skipped during fill-in rounds.
+        FA3_COMMIT,
     ],
     "python-version": [
-        # "3.10",   # No missing
-        # "3.11",   # No missing
+        "3.10",
+        "3.11",
         "3.12",
-        # "3.13",   # No missing
+        "3.13",
         "3.14",
-        # "3.13t",  # Covered by Group 2 (v0.9.27)
-        # "3.14t",  # Excluded entirely; see PR #102.
+        "3.13t",
+        # "3.14t",  # Excluded: torch 2.12.0's setuptools/cpp_extension cannot
+        # resolve the free-threaded import library on Windows
+        # (LNK1104: python314.lib vs python314t.lib). Re-enable once PyTorch
+        # / setuptools handle this for free-threaded CPython on Windows.
     ],
     "torch-version": [
         # "2.5.1",
         # "2.6.0",
         # "2.7.1",
         # "2.8.0",
-        "2.9.1",
-        "2.10.0",
-        # "2.11.0",  # No missing in Group 3
-        # "2.12.0",  # Covered by Group 1 (v0.9.26)
+        # "2.9.1",
+        # "2.10.0",
+        # "2.11.0",
+        "2.12.0",
     ],
     "cuda-version": [
         # "12.4",
         "12.6",
-        "12.8",
+        # "12.8",
         # "12.9",
         "13.0",
-        # "13.2",  # No missing in Group 3 (torch 2.9-2.10 don't support 13.2)
+        "13.2",
     ],
 }
 


### PR DESCRIPTION
## Summary

Final step (Step 4) of the Windows missing-wheel backfill. Restores `WINDOWS_SELF_HOSTED_MATRIX` to the regular full configuration now that backfill is complete.

## Backfill result: Windows 100% coverage 🎉

`check_missing_packages.py --platform windows` now reports **0 missing / 100.0% coverage** (132 existing, 60 excluded). Achieved across three fill-in rounds, each completing within the single self-hosted runner's 24h queue window:

| Round | Tag | Scope | missing |
|---|---|---|---|
| (start) | — | — | 21 (84.1%) |
| Group 1 | v0.9.26 | torch 2.12.0 holes | 13 (90.2%) |
| Group 2 | v0.9.27 | 3.13t × torch 2.9-2.11 | 4 (97.0%) |
| Group 3 | v0.9.28 | 3.12/3.14 × torch 2.9-2.10 | **0 (100%)** |

## Change

Reverts the temporary Group 1/2/3 scoping (PRs #103 / #104 / #105) and returns the matrix to:

```python
flash-attn: 2.8.3, FA3_COMMIT
python:     3.10, 3.11, 3.12, 3.13, 3.14, 3.13t   # 3.14t excluded per #102
torch:      2.12.0
cuda:       12.6, 13.0, 13.2
```

## Verification

The restored `WINDOWS_SELF_HOSTED_MATRIX` is **byte-for-byte identical** to the pre-backfill state (commit `6281735`, the PR #102 merge):

```
$ diff <(git show 6281735:create_matrix.py) create_matrix.py
>>> 完全一致 (no diff)
```

`uvx ruff format` / `uvx ruff check` both clean.

## Note

This PR only restores the matrix definition; it does not need a release tag. The next regular `v*` tag will use this full matrix again.

🤖 Generated with Claude Code
