### PR TITLE
chore(matrix/linux): scope to FA3 torch 2.5.1/2.6.0 holes for fill-in step 1

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -73,39 +73,46 @@ LINUX_ARM64_MATRIX = {
     ],
 }
 
+# Temporary matrix to fill missing Linux x86_64 wheels.
+# Step 1 of N (Group A): FA3 (flash_attn_3) holes for torch 2.5.1/2.6.0.
+# FA3 builds a single cp39-abi3 wheel per (torch, cuda) combination that
+# covers every non-free-threaded CPython, so we only need ONE python build
+# version here (3.12) to backfill all 12 missing FA3 entries
+# (fa3 × {3.10,3.11,3.12,3.13} × {2.5.1×12.4, 2.6.0×12.4, 2.6.0×12.6}).
+# Restore the original matrix after the Linux missing-wheel rounds are done.
 LINUX_SELF_HOSTED_MATRIX = {
     "flash-attn-version": [
-        "2.6.3",
-        "2.7.4",
-        "2.8.3",
+        # "2.6.3",
+        # "2.7.4",
+        # "2.8.3",
         FA3_COMMIT,
     ],
     "python-version": [
         # "3.10",
         # "3.11",
-        # "3.12",
+        "3.12",  # FA3 is abi3 (cp39-abi3); one build covers all non-FT pythons
         # "3.13",
         # "3.14",
-        "3.13t",
+        # "3.13t",
         # "3.14t",
     ],
     "torch-version": [
-        # "2.5.1",
+        "2.5.1",
         "2.6.0",
-        "2.7.1",
-        "2.8.0",
-        "2.9.1",
-        "2.10.0",
+        # "2.7.1",
+        # "2.8.0",
+        # "2.9.1",
+        # "2.10.0",
         # "2.11.0",
         # "2.12.0",
     ],
     "cuda-version": [
         "12.4",
         "12.6",
-        "12.8",
-        "12.9",
-        "13.0",
-        "13.2",
+        # "12.8",
+        # "12.9",
+        # "13.0",
+        # "13.2",
     ],
 }
 
@@ -321,8 +328,8 @@ def main():
                 "linux_arm64": False,
                 # "linux_arm64": LINUX_ARM64_MATRIX,
                 #
-                "linux_self_hosted": False,
-                # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
+                # "linux_self_hosted": False,
+                "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
                 #
                 "linux_arm64_self_hosted": False,
                 # "linux_arm64_self_hosted": LINUX_ARM64_SELF_HOSTED_MATRIX,
@@ -336,8 +343,8 @@ def main():
                 "windows": False,
                 # "windows": WINDOWS_MATRIX,
                 #
-                # "windows_self_hosted": False,
-                "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
+                "windows_self_hosted": False,
+                # "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
                 #
                 "windows_code_build": False,
                 # "windows_code_build": WINDOWS_CODEBUILD_MATRIX,


### PR DESCRIPTION
## Summary

Step **1** of the Linux x86_64 missing-wheel backfill. Linux x86_64 is currently at **92.4% coverage (35 missing)**; this round starts filling it via the self-hosted runners (`linux_self_hosted`).

Switches the active platform from `windows_self_hosted` (now 100%) to `linux_self_hosted`, scoped to **Group A — FA3 holes for torch 2.5.1 / 2.6.0**.

## Why only 1 build python for 12 missing entries

`check_missing_packages.py` lists 12 missing FA3 entries:

```
fa3 × {3.10, 3.11, 3.12, 3.13} × {2.5.1×12.4, 2.6.0×12.4, 2.6.0×12.6}
```

But FA3's `setup.py` builds with `py_limited_api="cp39"` / `-DPy_LIMITED_API=0x03090000`, so every FA3 wheel is tagged **`cp39-abi3`** regardless of the build python (verified: all 61 existing FA3 wheels are `cp39-abi3`). One build per `(torch, cuda)` therefore covers all non-free-threaded CPython versions.

So Group A only needs **one build python (3.12)**:

| Field | Values |
|---|---|
| `flash-attn-version` | FA3 (`fa3:e2743ab…`) |
| `python-version`     | `3.12` (abi3 → covers 3.10–3.14 non-FT) |
| `torch-version`      | `2.5.1`, `2.6.0` |
| `cuda-version`       | `12.4`, `12.6` |

Cross product after `EXCLUDE` = **3 jobs**:

```
fa3 × 3.12 × 2.5.1 × 12.4
fa3 × 3.12 × 2.6.0 × 12.4
fa3 × 3.12 × 2.6.0 × 12.6
```

(`2.5.1×12.6` excluded — torch 2.5 does not support CUDA 12.6.)

These 3 abi3 wheels backfill all **12** missing FA3 entries.

## Note / risk

Whether FA3 (hopper) actually builds against the older torch 2.5.1 / 2.6.0 is **unverified** — that's why FA3 goes first as the smallest group. If a build fails, we'll know early and can decide whether to drop those FA3×old-torch combinations from the coverage matrix.

## Plan (grouped, sequential — same flow as the Windows backfill)

| Step | Group | jobs | missing |
|---|---|---|---|
| **1 (this PR)** | A: FA3 × torch 2.5.1/2.6.0 | 3 | 12 |
| 2 | B: FA2 × 3.14t × 2.9.1 | 9 | 9 |
| 3 | C: FA2 × 3.13t × 2.11.0 | 9 | 9 |
| 4 | D1: FA2 × 3.13 × 2.5.1 | 3 | 3 |
| 5 | D2: FA2 × 2.11.0 leftovers | 8 | 2 |

Total 32 jobs → 35 missing → target 100%. A restore PR follows at the end.

## How to use

1. Merge this PR.
2. Push the next `v*` tag on the merge commit.
3. After the run completes, confirm `check_missing_packages.py --platform linux` reports 12 fewer missing — and importantly, that FA3 builds succeeded.
4. Proceed to step 2 (Group B).

🤖 Generated with Claude Code
