### PR TITLE
chore(matrix/linux): scope to FA2 3.14t torch 2.9.1 holes for fill-in step 2

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -74,44 +74,43 @@ LINUX_ARM64_MATRIX = {
 }
 
 # Temporary matrix to fill missing Linux x86_64 wheels.
-# Step 1 of N (Group A): FA3 (flash_attn_3) holes for torch 2.5.1/2.6.0.
-# FA3 builds a single cp39-abi3 wheel per (torch, cuda) combination that
-# covers every non-free-threaded CPython, so we only need ONE python build
-# version here (3.12) to backfill all 12 missing FA3 entries
-# (fa3 × {3.10,3.11,3.12,3.13} × {2.5.1×12.4, 2.6.0×12.4, 2.6.0×12.6}).
+# Step 2 of N (Group B): FA2 free-threaded 3.14t holes for torch 2.9.1.
+# Group A (v0.9.29) already backfilled the 12 FA3 holes (95.0% coverage).
+# Group B covers 9 missing entries:
+#   {2.6.3, 2.7.4, 2.8.3} × 3.14t × 2.9.1 × {12.6, 12.8, 13.0}
 # Restore the original matrix after the Linux missing-wheel rounds are done.
 LINUX_SELF_HOSTED_MATRIX = {
     "flash-attn-version": [
-        # "2.6.3",
-        # "2.7.4",
-        # "2.8.3",
-        FA3_COMMIT,
+        "2.6.3",
+        "2.7.4",
+        "2.8.3",
+        # FA3_COMMIT,  # Done in Group A
     ],
     "python-version": [
         # "3.10",
         # "3.11",
-        "3.12",  # FA3 is abi3 (cp39-abi3); one build covers all non-FT pythons
+        # "3.12",
         # "3.13",
         # "3.14",
         # "3.13t",
-        # "3.14t",
+        "3.14t",
     ],
     "torch-version": [
-        "2.5.1",
-        "2.6.0",
+        # "2.5.1",
+        # "2.6.0",
         # "2.7.1",
         # "2.8.0",
-        # "2.9.1",
+        "2.9.1",
         # "2.10.0",
         # "2.11.0",
         # "2.12.0",
     ],
     "cuda-version": [
-        "12.4",
+        # "12.4",
         "12.6",
-        # "12.8",
+        "12.8",
         # "12.9",
-        # "13.0",
+        "13.0",
         # "13.2",
     ],
 }


### PR DESCRIPTION
## Summary

Step **2** of the Linux x86_64 missing-wheel backfill. **Group B — FA2 free-threaded `3.14t` holes for torch 2.9.1.**

## Progress

| | missing | coverage |
|---|---|---|
| start | 35 | 92.4% |
| after Group A (v0.9.29) | 23 | 95.0% |
| **target after Group B** | **14** | **~96.9%** |

Group A confirmed FA3 builds successfully against the older torch 2.5.1 / 2.6.0 (all 3 abi3 jobs green → 12 missing filled).

## Group B matrix

| Field | Values |
|---|---|
| `flash-attn-version` | `2.6.3`, `2.7.4`, `2.8.3` |
| `python-version`     | `3.14t` |
| `torch-version`      | `2.9.1` |
| `cuda-version`       | `12.6`, `12.8`, `13.0` |

Cross product after `EXCLUDE` = **9 jobs**, all missing (verified — no rebuilds):

```
{2.6.3, 2.7.4, 2.8.3} × 3.14t × 2.9.1 × {12.6, 12.8, 13.0}
```

Unlike Windows (where `3.14t` hit `LNK1104: python314.lib`), Linux builds a `.so` and links the free-threaded ABI directly, so `3.14t` builds fine here (`3.13t` already ships on Linux).

## Remaining after this step

- Group C — `3.13t × torch 2.11.0` (9)
- Group D1 — `3.13 × torch 2.5.1` (3)
- Group D2 — `2.11.0` leftovers (2)

## How to use

1. Merge this PR.
2. Push the next `v*` tag on the merge commit.
3. After completion, confirm `check_missing_packages.py --platform linux` reports 9 fewer missing.
4. Proceed to step 3 (Group C).

🤖 Generated with Claude Code
