### PR TITLE
chore(matrix/linux): scope to FA2 3.13t torch 2.11.0 holes for fill-in step 3

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -74,10 +74,10 @@ LINUX_ARM64_MATRIX = {
 }
 
 # Temporary matrix to fill missing Linux x86_64 wheels.
-# Step 2 of N (Group B): FA2 free-threaded 3.14t holes for torch 2.9.1.
-# Group A (v0.9.29) already backfilled the 12 FA3 holes (95.0% coverage).
-# Group B covers 9 missing entries:
-#   {2.6.3, 2.7.4, 2.8.3} × 3.14t × 2.9.1 × {12.6, 12.8, 13.0}
+# Step 3 of N (Group C): FA2 free-threaded 3.13t holes for torch 2.11.0.
+# Groups A (v0.9.29) and B (v0.9.30) backfilled FA3 and the 3.14t/2.9.1
+# holes (97.0% coverage). Group C covers 9 missing entries:
+#   {2.6.3, 2.7.4, 2.8.3} × 3.13t × 2.11.0 × {12.6, 12.8, 13.0}
 # Restore the original matrix after the Linux missing-wheel rounds are done.
 LINUX_SELF_HOSTED_MATRIX = {
     "flash-attn-version": [
@@ -92,17 +92,17 @@ LINUX_SELF_HOSTED_MATRIX = {
         # "3.12",
         # "3.13",
         # "3.14",
-        # "3.13t",
-        "3.14t",
+        "3.13t",
+        # "3.14t",  # Done in Group B
     ],
     "torch-version": [
         # "2.5.1",
         # "2.6.0",
         # "2.7.1",
         # "2.8.0",
-        "2.9.1",
+        # "2.9.1",
         # "2.10.0",
-        # "2.11.0",
+        "2.11.0",
         # "2.12.0",
     ],
     "cuda-version": [


### PR DESCRIPTION
## Summary

Step **3** of the Linux x86_64 missing-wheel backfill. **Group C — FA2 free-threaded `3.13t` holes for torch 2.11.0.**

## Progress

| | missing | coverage |
|---|---|---|
| start | 35 | 92.4% |
| after Group A (v0.9.29) | 23 | 95.0% |
| after Group B (v0.9.30) | 14 | 97.0% |
| **target after Group C** | **5** | **~98.9%** |

## Group C matrix

| Field | Values |
|---|---|
| `flash-attn-version` | `2.6.3`, `2.7.4`, `2.8.3` |
| `python-version`     | `3.13t` |
| `torch-version`      | `2.11.0` |
| `cuda-version`       | `12.6`, `12.8`, `13.0` |

Cross product after `EXCLUDE` = **9 jobs**, all missing (verified, no rebuilds).

## Remaining after this step

- Group D1 — `3.13 × torch 2.5.1 × 12.4` (3)
- Group D2 — `2.11.0` leftovers: `2.6.3×3.13×12.6`, `2.7.4×3.11×13.0` (2)

🤖 Generated with Claude Code
