### PR TITLE
chore(matrix/linux): restore full self-hosted matrix after backfill

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -73,47 +73,39 @@ LINUX_ARM64_MATRIX = {
     ],
 }
 
-# Temporary matrix to fill missing Linux x86_64 wheels.
-# Step 5 of N (Group D2, FINAL): the two leftover torch 2.11.0 holes.
-# Groups A/B/C/D1 brought coverage to 99.6%; this final group covers:
-#   2.6.3 × 3.13 × 2.11.0 × 12.6  and  2.7.4 × 3.11 × 2.11.0 × 13.0
-# These two individual points are picked up via a small cross product
-# ({2.6.3,2.7.4} × {3.11,3.13} × 2.11.0 × {12.6,13.0} = 8 jobs), of which
-# 2 are missing and 6 are existing wheels rebuilt and re-uploaded via
-# --clobber. Restore the regular matrix in the follow-up PR.
 LINUX_SELF_HOSTED_MATRIX = {
     "flash-attn-version": [
         "2.6.3",
         "2.7.4",
-        # "2.8.3",  # No 2.11.0 leftover for 2.8.3
-        # FA3_COMMIT,  # Done in Group A
+        "2.8.3",
+        FA3_COMMIT,
     ],
     "python-version": [
         # "3.10",
-        "3.11",
+        # "3.11",
         # "3.12",
-        "3.13",
+        # "3.13",
         # "3.14",
-        # "3.13t",  # Done in Group C
-        # "3.14t",  # Done in Group B
+        "3.13t",
+        # "3.14t",
     ],
     "torch-version": [
         # "2.5.1",
-        # "2.6.0",
-        # "2.7.1",
-        # "2.8.0",
-        # "2.9.1",
-        # "2.10.0",
-        "2.11.0",
+        "2.6.0",
+        "2.7.1",
+        "2.8.0",
+        "2.9.1",
+        "2.10.0",
+        # "2.11.0",
         # "2.12.0",
     ],
     "cuda-version": [
-        # "12.4",
+        "12.4",
         "12.6",
-        # "12.8",
-        # "12.9",
+        "12.8",
+        "12.9",
         "13.0",
-        # "13.2",
+        "13.2",
     ],
 }
 
@@ -329,8 +321,8 @@ def main():
                 "linux_arm64": False,
                 # "linux_arm64": LINUX_ARM64_MATRIX,
                 #
-                # "linux_self_hosted": False,
-                "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
+                "linux_self_hosted": False,
+                # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
                 #
                 "linux_arm64_self_hosted": False,
                 # "linux_arm64_self_hosted": LINUX_ARM64_SELF_HOSTED_MATRIX,
@@ -344,8 +336,8 @@ def main():
                 "windows": False,
                 # "windows": WINDOWS_MATRIX,
                 #
-                "windows_self_hosted": False,
-                # "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
+                # "windows_self_hosted": False,
+                "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
                 #
                 "windows_code_build": False,
                 # "windows_code_build": WINDOWS_CODEBUILD_MATRIX,


### PR DESCRIPTION
## Summary

Final step of the Linux x86_64 backfill. Restores `create_matrix.py` to its pre-backfill configuration now that Linux x86_64 has reached **100% coverage**.

## Backfill result: Linux x86_64 100% 🎉

`check_missing_packages.py --platform linux` now reports **0 missing / 100.0% coverage** (461 existing, 883 excluded). Achieved across five grouped rounds on the self-hosted runners:

| Round | Tag | Scope | missing |
|---|---|---|---|
| (start) | — | — | 35 (92.4%) |
| Group A | v0.9.29 | FA3 × torch 2.5.1/2.6.0 (abi3, 1 build py) | 23 (95.0%) |
| Group B | v0.9.30 | 3.14t × torch 2.9.1 | 14 (97.0%) |
| Group C | v0.9.31 | 3.13t × torch 2.11.0 | 5 (98.9%) |
| Group D1 | v0.9.32 | 3.13 × torch 2.5.1 | 2 (99.6%) |
| Group D2 | v0.9.33 | torch 2.11.0 leftovers | **0 (100%)** |

## Change

Reverts the temporary Group A-D2 scoping (PRs #107-#111) and returns `create_matrix.py` to commit `8e3f888`:

- `LINUX_SELF_HOSTED_MATRIX` → regular configuration (2.6.3/2.7.4/2.8.3 + FA3, 3.13t, torch 2.6-2.10, cuda 12.4-13.2)
- `main()` → `linux_self_hosted` disabled, `windows_self_hosted` enabled (pre-backfill default)

## Verification

`create_matrix.py` is **byte-for-byte identical** to the pre-backfill state (`8e3f888`):

```
$ diff <(git show 8e3f888:create_matrix.py) create_matrix.py
>>> (no diff)
```

`uvx ruff format` / `uvx ruff check` both clean. No release tag needed for this PR.

🤖 Generated with Claude Code
