### PR TITLE
chore(matrix/arm64): build FA2 free-threaded holes on GitHub-hosted runners

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -40,26 +40,37 @@ LINUX_MATRIX = {
     ],
 }
 
+# Temporary matrix to fill missing Linux ARM64 wheels on GitHub-hosted
+# runners (ubuntu-22.04-arm). FA3 is excluded for now because its ARM64
+# build runs ~12-17h on the available hardware and overruns the 6h
+# GitHub-hosted job limit; only the FA2 free-threaded holes are built here.
+# Group covers 24 missing entries (all of flash-attn 2.8.3):
+#   {3.13t, 3.14t} × {2.9.1, 2.10.0, 2.11.0, 2.12.0} × {12.6, 12.8, 13.0, 13.2}
+# (torch 2.9-2.11 drop 13.2 and torch 2.12 drops 12.8 via EXCLUDE -> 24 jobs)
+# Restore the original matrix after the ARM64 missing-wheel round is done.
 LINUX_ARM64_MATRIX = {
     "flash-attn-version": [
-        "2.6.3",
-        "2.7.4",
+        # "2.6.3",  # No ARM64 missing
+        # "2.7.4",  # No ARM64 missing
         "2.8.3",
+        # FA3_COMMIT,  # Excluded: ARM64 FA3 build overruns the 6h GH-hosted limit
     ],
     "python-version": [
-        "3.10",
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
+        # "3.10",
+        # "3.11",
+        # "3.12",
+        # "3.13",
+        # "3.14",
+        "3.13t",
+        "3.14t",
     ],
     "torch-version": [
         # "2.5.1",
         # "2.6.0",
         # "2.7.1",
         # "2.8.0",
-        # "2.9.1",
-        # "2.10.0",
+        "2.9.1",
+        "2.10.0",
         "2.11.0",
         "2.12.0",
     ],
@@ -318,8 +329,8 @@ def main():
                 "linux": False,
                 # "linux": LINUX_MATRIX,
                 #
-                "linux_arm64": False,
-                # "linux_arm64": LINUX_ARM64_MATRIX,
+                # "linux_arm64": False,
+                "linux_arm64": LINUX_ARM64_MATRIX,
                 #
                 "linux_self_hosted": False,
                 # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
@@ -336,8 +347,8 @@ def main():
                 "windows": False,
                 # "windows": WINDOWS_MATRIX,
                 #
-                # "windows_self_hosted": False,
-                "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
+                "windows_self_hosted": False,
+                # "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
                 #
                 "windows_code_build": False,
                 # "windows_code_build": WINDOWS_CODEBUILD_MATRIX,


### PR DESCRIPTION
## Summary

Start the Linux ARM64 missing-wheel backfill on **GitHub-hosted runners** (`ubuntu-22.04-arm`). Builds the **FA2 free-threaded** holes; **FA3 is excluded** for now.

## Current state

Linux ARM64: **54 missing / 62.5% coverage** (existing 90), split into:

| 系統 | missing | 実ビルド本数 | GitHub-hosted 6h |
|---|---|---|---|
| FA3 (abi3) | 30 | 6 | ❌ overruns (self-hosted 12-17h) — **excluded this round** |
| **FA2 free-threaded (2.8.3)** | 24 | 24 | ✅ fits (FA2 ARM64 historically ≤5.9h) |

## This round's matrix (FA2 free-threaded)

| Field | Values |
|---|---|
| `flash-attn-version` | `2.8.3` |
| `python-version`     | `3.13t`, `3.14t` |
| `torch-version`      | `2.9.1`, `2.10.0`, `2.11.0`, `2.12.0` |
| `cuda-version`       | `12.6`, `12.8`, `13.0`, `13.2` |

After `EXCLUDE` (torch 2.9–2.11 drop cuda 13.2; torch 2.12 drops 12.8) = **24 jobs, all missing** (verified, no rebuilds).

Runs via the `linux_arm64` path (`_build_linux.yml` on `ubuntu-22.04-arm`, GitHub-hosted). Switches active platform from `windows_self_hosted` (now 100%) to `linux_arm64`.

## Notes

- GitHub-hosted runs jobs in parallel, so no grouping/24h-queue concern as with self-hosted — all 24 go in one tag.
- **6h risk**: historical ARM64 GitHub-hosted FA2 data tops out at 5.9h, but that sample only covered torch ≤2.10. torch 2.11/2.12 timings are unknown; if any job hits the 6h limit, it can be re-run or moved to a larger runner.
- **FA3 ARM64** (6 abi3 builds) will be tackled separately — GitHub-hosted larger ARM runner or self-hosted.

## How to use

1. Merge this PR.
2. Push the next `v*` tag.
3. After completion, confirm `check_missing_packages.py --platform linux_arm64` drops by 24 (54 → 30, FA3-only remaining).

🤖 Generated with Claude Code
