### PR TITLE
chore(matrix/arm64): restore matrix after FA2 GitHub-hosted backfill

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -40,37 +40,26 @@ LINUX_MATRIX = {
     ],
 }
 
-# Temporary matrix to fill missing Linux ARM64 wheels on GitHub-hosted
-# runners (ubuntu-22.04-arm). FA3 is excluded for now because its ARM64
-# build runs ~12-17h on the available hardware and overruns the 6h
-# GitHub-hosted job limit; only the FA2 free-threaded holes are built here.
-# Group covers 24 missing entries (all of flash-attn 2.8.3):
-#   {3.13t, 3.14t} × {2.9.1, 2.10.0, 2.11.0, 2.12.0} × {12.6, 12.8, 13.0, 13.2}
-# (torch 2.9-2.11 drop 13.2 and torch 2.12 drops 12.8 via EXCLUDE -> 24 jobs)
-# Restore the original matrix after the ARM64 missing-wheel round is done.
 LINUX_ARM64_MATRIX = {
     "flash-attn-version": [
-        # "2.6.3",  # No ARM64 missing
-        # "2.7.4",  # No ARM64 missing
+        "2.6.3",
+        "2.7.4",
         "2.8.3",
-        # FA3_COMMIT,  # Excluded: ARM64 FA3 build overruns the 6h GH-hosted limit
     ],
     "python-version": [
-        # "3.10",
-        # "3.11",
-        # "3.12",
-        # "3.13",
-        # "3.14",
-        "3.13t",
-        "3.14t",
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
     ],
     "torch-version": [
         # "2.5.1",
         # "2.6.0",
         # "2.7.1",
         # "2.8.0",
-        "2.9.1",
-        "2.10.0",
+        # "2.9.1",
+        # "2.10.0",
         "2.11.0",
         "2.12.0",
     ],
@@ -329,8 +318,8 @@ def main():
                 "linux": False,
                 # "linux": LINUX_MATRIX,
                 #
-                # "linux_arm64": False,
-                "linux_arm64": LINUX_ARM64_MATRIX,
+                "linux_arm64": False,
+                # "linux_arm64": LINUX_ARM64_MATRIX,
                 #
                 "linux_self_hosted": False,
                 # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
@@ -347,8 +336,8 @@ def main():
                 "windows": False,
                 # "windows": WINDOWS_MATRIX,
                 #
-                "windows_self_hosted": False,
-                # "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
+                # "windows_self_hosted": False,
+                "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
                 #
                 "windows_code_build": False,
                 # "windows_code_build": WINDOWS_CODEBUILD_MATRIX,


### PR DESCRIPTION
## Summary

Restores `create_matrix.py` after the Linux ARM64 **FA2 free-threaded** backfill on GitHub-hosted runners.

## Result

| | value |
|---|---|
| ARM64 existing | 90 → **113** (+23) |
| ARM64 coverage | 62.5% → **78.5%** |
| FA2 free-threaded built | **23 / 24** |
| FA2 abandoned (6h timeout) | 1 — `2.8.3 × 3.13t × 2.11.0 × 12.8` (cancelled at exactly 360 min) |

23 of the 24 FA2 free-threaded wheels built within the 6h GitHub-hosted limit. The one remaining FA2 entry overran 6h and is intentionally skipped per the goal ("6h overruns are acceptable to abandon").

## Change

Reverts PR #114's temporary scoping — `create_matrix.py` back to `c6e3da7`:
- `LINUX_ARM64_MATRIX` → regular configuration
- `main()` → `linux_arm64` disabled, `windows_self_hosted` enabled

Verified byte-for-byte identical to `c6e3da7`.

## Remaining ARM64 work (not in this PR)

- **FA3** — 30 missing / 6 abi3 builds. ARM64 FA3 runs ~12-17h on available hardware, well over the 6h GitHub-hosted limit. Needs a larger ARM runner or self-hosted.
- **1 FA2 timeout** — `3.13t × 2.11.0 × 12.8` (6h overrun). Could be retried on a larger runner if desired.

🤖 Generated with Claude Code
