### PR TITLE
feat(build/linux): add optional ccache support toggled by workflow input

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "Whether to clean up Python installation"
     required: false
     default: "false"
+  use-ccache:
+    description: "Whether to use ccache to speed up compilation"
+    required: false
+    default: "false"
 
 outputs:
   wheel-path:
@@ -50,8 +54,27 @@ runs:
       with:
         version: ${{ inputs.cuda-version }}
 
+    - name: Install ccache
+      if: ${{ inputs.use-ccache == 'true' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ccache
+
+    - name: Restore ccache
+      if: ${{ inputs.use-ccache == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: ~/.ccache
+        key: ccache-linux-${{ runner.arch }}-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}-fa${{ inputs.flash-attn-version }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: |
+          ccache-linux-${{ runner.arch }}-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}-fa${{ inputs.flash-attn-version }}-
+          ccache-linux-${{ runner.arch }}-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}-
+
     - name: Build wheels
       shell: bash
+      env:
+        USE_CCACHE: ${{ inputs.use-ccache == 'true' && '1' || '0' }}
       run: |
         chmod +x build_linux.sh
         ./build_linux.sh ${{ inputs.flash-attn-version }} ${{ inputs.python-version }} ${{ inputs.torch-version }} ${{ inputs.cuda-version }}

--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: true
+      use-ccache:
+        description: "Whether to use ccache to speed up compilation"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build_wheels:
@@ -66,3 +71,4 @@ jobs:
           torch-version: ${{ inputs.torch-version }}
           cuda-version: ${{ inputs.cuda-version }}
           is-upload: ${{ inputs.is-upload }}
+          use-ccache: ${{ inputs.use-ccache }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -55,6 +55,11 @@ on:
         description: "NVCC_THREADS (optional, overrides auto-detection)"
         required: false
         type: string
+      use-ccache:
+        description: "Use ccache to speed up compilation (GitHub-hosted Linux only)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   # #########################################################
@@ -99,6 +104,7 @@ jobs:
       cuda-version: ${{ inputs.cuda-version }}
       is-upload: false
       runner: ubuntu-22.04-arm
+      use-ccache: ${{ inputs.use-ccache }}
 
   # #########################################################
   # Linux ARM64 self-hosted runner

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -110,6 +110,46 @@ echo "Build parallelism settings:"
 echo "  MAX_JOBS: $MAX_JOBS"
 echo "  NVCC_THREADS: $NVCC_THREADS"
 
+# Optional ccache setup (enabled with USE_CCACHE=1).
+# Speeds up rebuilds by caching compiled objects. Useful for retrying builds
+# that hit the GitHub-hosted 6h limit: the second run reuses cached objects.
+if [[ "${USE_CCACHE:-0}" == "1" ]]; then
+  if command -v ccache >/dev/null 2>&1; then
+    echo "ccache: enabled"
+    export CCACHE_DIR="${CCACHE_DIR:-$HOME/.ccache}"
+    export CCACHE_MAXSIZE="${CCACHE_MAXSIZE:-5G}"
+    # Hash only file content, not mtime/path, so cache hits survive fresh clones.
+    export CCACHE_COMPILERCHECK="${CCACHE_COMPILERCHECK:-content}"
+    ccache -M "$CCACHE_MAXSIZE" >/dev/null 2>&1 || true
+
+    # Host compiler (gcc/g++): use ccache's masquerade dir on PATH so that
+    # tools resolving the compiler by name go through ccache.
+    if [ -d /usr/lib/ccache ]; then
+      export PATH="/usr/lib/ccache:$PATH"
+    fi
+
+    # nvcc: PyTorch's cpp_extension invokes $CUDA_HOME/bin/nvcc by absolute
+    # path, so PATH masquerade does not apply. Replace nvcc with a wrapper that
+    # routes through ccache. The real binary is kept under the original name
+    # "nvcc" (so ccache still detects the CUDA compiler type).
+    NVCC_BIN=$(command -v nvcc || true)
+    REAL_NVCC="$HOME/.ccache-nvcc-real/nvcc"
+    if [ -n "$NVCC_BIN" ] && [ ! -f "$REAL_NVCC" ]; then
+      mkdir -p "$(dirname "$REAL_NVCC")"
+      cp "$NVCC_BIN" "$REAL_NVCC"
+      sudo tee "$NVCC_BIN" >/dev/null <<EOF
+#!/usr/bin/env bash
+exec ccache "$REAL_NVCC" "\$@"
+EOF
+      sudo chmod +x "$NVCC_BIN"
+      echo "ccache: wrapped nvcc ($NVCC_BIN -> ccache $REAL_NVCC)"
+    fi
+    ccache -z >/dev/null 2>&1 || true
+  else
+    echo "ccache: USE_CCACHE=1 but ccache not found on PATH; building without it"
+  fi
+fi
+
 # Build wheels
 echo "Building wheels..."
 if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
@@ -126,3 +166,9 @@ NVCC_THREADS=$NVCC_THREADS MAX_JOBS=$MAX_JOBS \
   time python setup.py bdist_wheel --dist-dir=dist
 wheel_name=$(basename $(ls dist/*.whl | head -n 1))
 echo "Built wheel: $wheel_name"
+
+# Report ccache statistics (hit/miss) when enabled.
+if [[ "${USE_CCACHE:-0}" == "1" ]] && command -v ccache >/dev/null 2>&1; then
+  echo "=== ccache statistics ==="
+  ccache -s || true
+fi


### PR DESCRIPTION
## Summary

Add **opt-in ccache** support to the GitHub-hosted Linux build path, toggled by a `use-ccache` workflow input. **Off by default.**

Motivation: ARM64 builds that hit the GitHub-hosted **6h job limit** (e.g. the FA2 `3.13t × 2.11.0 × 12.8` wheel that timed out at exactly 360 min with 72/73 objects compiled, and FA3 ARM64 which runs 12-17h). With a warm ccache, a retry reuses already-compiled objects and finishes well under 6h.

## How it works

PyTorch's `cpp_extension` invokes `$CUDA_HOME/bin/nvcc` by **absolute path**, so a PATH masquerade alone can't intercept nvcc. So:

- **Host compiler** (gcc/g++): `/usr/lib/ccache` prepended to PATH (standard ccache masquerade).
- **nvcc**: replaced with a wrapper that runs `ccache <real-nvcc>`. The real binary is kept under the name `nvcc` so ccache still detects the CUDA compiler type (ccache ≥4.x supports CUDA).

The cache is restored/saved across runs via `actions/cache`, keyed by `arch / cuda / torch / python / flash-attn` (+ run id, with `restore-keys` fallback to the latest matching cache).

## Changes

| File | Change |
|---|---|
| `build_linux.sh` | `USE_CCACHE=1` → set up ccache (host masquerade + nvcc wrapper, `CCACHE_COMPILERCHECK=content`, 5G cap), print `ccache -s` after build. **No-op when unset** → self-hosted/container paths unaffected |
| `.github/actions/build-and-upload/action.yml` | `use-ccache` input; install ccache; `actions/cache` for `~/.ccache`; pass `USE_CCACHE` to the script |
| `.github/workflows/_build_linux.yml` | `use-ccache` input (default `false`) forwarded to the action |
| `.github/workflows/test-build.yml` | `use-ccache` dispatch input (default `false`) wired to the `linux-arm64` job |

## Scope / safety

- **Default off** everywhere; existing builds are byte-for-byte unchanged unless `use-ccache: true` is passed.
- Only the **GitHub-hosted Linux path** (`_build_linux.yml` / `build-and-upload`) is wired up. Self-hosted and container paths are untouched (and `build_linux.sh` is a no-op without `USE_CCACHE`).
- `build.yml` (production tag builds) is intentionally **not** flipped on — ccache can be enabled per-job later when running ARM64 backfills.

## How to test

```
gh workflow run "Test build" --ref feat/ccache-optional-linux-build \
  -f platform=linux-arm64 -f flash-attn-version=2.8.3 \
  -f python-version=3.13t -f torch-version=2.11.0 -f cuda-version=12.8 \
  -f use-ccache=true
```

Run twice: first warms the cache, second should show high ccache hit rate in the `ccache -s` output and finish much faster.

🤖 Generated with Claude Code
