### PR TITLE
chore(matrix/arm64): retry 6h-timeout FA2 wheel with ccache enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
       torch-version: ${{ matrix.torch-version }}
       cuda-version: ${{ matrix.cuda-version }}
       runner: "ubuntu-22.04-arm"
+      use-ccache: true
     secrets: inherit
 
   # ################ Self-hosted runner ################

--- a/create_matrix.py
+++ b/create_matrix.py
@@ -40,18 +40,24 @@ LINUX_MATRIX = {
     ],
 }
 
+# Temporary matrix to retry the single ARM64 FA2 wheel that hit the 6h
+# GitHub-hosted limit in v0.9.34 (2.8.3 × 3.13t × 2.11.0 × 12.8, cancelled at
+# 360 min with 72/73 objects compiled). Built with ccache enabled (see
+# build.yml linux_arm64 use-ccache) so a warm cache lets the build finish
+# within 6h. Restore the original matrix afterwards.
 LINUX_ARM64_MATRIX = {
     "flash-attn-version": [
-        "2.6.3",
-        "2.7.4",
+        # "2.6.3",
+        # "2.7.4",
         "2.8.3",
     ],
     "python-version": [
-        "3.10",
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
+        # "3.10",
+        # "3.11",
+        # "3.12",
+        # "3.13",
+        # "3.14",
+        "3.13t",
     ],
     "torch-version": [
         # "2.5.1",
@@ -61,15 +67,15 @@ LINUX_ARM64_MATRIX = {
         # "2.9.1",
         # "2.10.0",
         "2.11.0",
-        "2.12.0",
+        # "2.12.0",
     ],
     "cuda-version": [
         # "12.4",
-        "12.6",
+        # "12.6",
         "12.8",
         # "12.9",
-        "13.0",
-        "13.2",
+        # "13.0",
+        # "13.2",
     ],
 }
 
@@ -318,8 +324,8 @@ def main():
                 "linux": False,
                 # "linux": LINUX_MATRIX,
                 #
-                "linux_arm64": False,
-                # "linux_arm64": LINUX_ARM64_MATRIX,
+                # "linux_arm64": False,
+                "linux_arm64": LINUX_ARM64_MATRIX,
                 #
                 "linux_self_hosted": False,
                 # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
@@ -336,8 +342,8 @@ def main():
                 "windows": False,
                 # "windows": WINDOWS_MATRIX,
                 #
-                # "windows_self_hosted": False,
-                "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
+                "windows_self_hosted": False,
+                # "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
                 #
                 "windows_code_build": False,
                 # "windows_code_build": WINDOWS_CODEBUILD_MATRIX,


### PR DESCRIPTION
Retry the single ARM64 FA2 wheel that timed out at 6h in v0.9.34 (`2.8.3 × 3.13t × 2.11.0 × 12.8`, cancelled at 360 min with 72/73 objects compiled), now with **ccache enabled** (PR #116).

## Changes
- `create_matrix.py`: scope `LINUX_ARM64_MATRIX` to the single timed-out combination; enable `linux_arm64`, disable `windows_self_hosted`.
- `build.yml`: `use-ccache: true` on the `linux_arm64` job.

## Expectation
- **1st run**: cold cache → may again approach 6h, but `actions/cache` should save the partial cache (to be observed).
- **2nd run** (re-run / re-tag): warm cache → reuses 72 objects, finishes well within 6h.

If the cold run's cache is *not* saved on a 6h hard-cancel, fall back to a shorter build step timeout or a larger ARM runner.

Restore the full ARM64 matrix + revert `use-ccache` after success.

🤖 Generated with Claude Code