### PR TITLE
fix(build/linux): keep ccache-wrapped nvcc in its original bin dir

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -130,19 +130,24 @@ if [[ "${USE_CCACHE:-0}" == "1" ]]; then
 
     # nvcc: PyTorch's cpp_extension invokes $CUDA_HOME/bin/nvcc by absolute
     # path, so PATH masquerade does not apply. Replace nvcc with a wrapper that
-    # routes through ccache. The real binary is kept under the original name
-    # "nvcc" (so ccache still detects the CUDA compiler type).
+    # routes through ccache. The real binary MUST stay in the same bin dir
+    # (renamed nvcc.real), otherwise nvcc cannot locate its sibling tools
+    # (cicc, ptxas, nvvm) by relative path and fails with "cicc: not found".
     NVCC_BIN=$(command -v nvcc || true)
-    REAL_NVCC="$HOME/.ccache-nvcc-real/nvcc"
-    if [ -n "$NVCC_BIN" ] && [ ! -f "$REAL_NVCC" ]; then
-      mkdir -p "$(dirname "$REAL_NVCC")"
-      cp "$NVCC_BIN" "$REAL_NVCC"
-      sudo tee "$NVCC_BIN" >/dev/null <<EOF
+    if [ -n "$NVCC_BIN" ]; then
+      NVCC_DIR=$(dirname "$NVCC_BIN")
+      if [ ! -f "$NVCC_DIR/nvcc.real" ]; then
+        sudo mv "$NVCC_BIN" "$NVCC_DIR/nvcc.real"
+        sudo tee "$NVCC_BIN" >/dev/null <<EOF
 #!/usr/bin/env bash
-exec ccache "$REAL_NVCC" "\$@"
+exec ccache "$NVCC_DIR/nvcc.real" "\$@"
 EOF
-      sudo chmod +x "$NVCC_BIN"
-      echo "ccache: wrapped nvcc ($NVCC_BIN -> ccache $REAL_NVCC)"
+        sudo chmod +x "$NVCC_BIN"
+        echo "ccache: wrapped nvcc (real at $NVCC_DIR/nvcc.real)"
+      fi
+      # The real binary's basename is "nvcc.real", so tell ccache explicitly
+      # that this is the CUDA compiler (ccache >= 4.4 supports CCACHE_COMPILERTYPE).
+      export CCACHE_COMPILERTYPE=nvcc
     fi
     ccache -z >/dev/null 2>&1 || true
   else


### PR DESCRIPTION
## Problem

The ccache nvcc wrapper from PR #116 copied the real nvcc to `$HOME/.ccache-nvcc-real/nvcc`. But nvcc finds its sibling tools (`cicc`, `ptxas`, `nvvm/`) **relative to its own location**, so running it from that directory failed instantly:

```
sh: 1: cicc: not found
FAILED: [code=127] ...flash_bwd_hdim128_bf16_causal_sm80.o
RuntimeError: Error compiling objects for extension
```

The v0.9.35 ARM64 retry (`2.8.3 × 3.13t × 2.11.0 × 12.8`) died after 43s for this reason. ccache itself was enabled and the cache restore worked — only the wrapper's placement was wrong.

## Fix

- Rename the real binary **in place**: `$CUDA_HOME/bin/nvcc` → `$CUDA_HOME/bin/nvcc.real`, and point the wrapper there. The toolchain is now resolved by relative path.
- Set `CCACHE_COMPILERTYPE=nvcc` so ccache still recognizes the CUDA compiler despite the `nvcc.real` basename.

No-op unless `USE_CCACHE=1`.

## Next

After merge, re-tag to retry the timed-out ARM64 wheel with a working ccache setup (1st run = cold/build the cache, 2nd = warm/finish within 6h).

🤖 Generated with Claude Code