### PR TITLE
chore(matrix/arm64): restore matrix after ccache retry succeeded

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -40,24 +40,18 @@ LINUX_MATRIX = {
     ],
 }
 
-# Temporary matrix to retry the single ARM64 FA2 wheel that hit the 6h
-# GitHub-hosted limit in v0.9.34 (2.8.3 × 3.13t × 2.11.0 × 12.8, cancelled at
-# 360 min with 72/73 objects compiled). Built with ccache enabled (see
-# build.yml linux_arm64 use-ccache) so a warm cache lets the build finish
-# within 6h. Restore the original matrix afterwards.
 LINUX_ARM64_MATRIX = {
     "flash-attn-version": [
-        # "2.6.3",
-        # "2.7.4",
+        "2.6.3",
+        "2.7.4",
         "2.8.3",
     ],
     "python-version": [
-        # "3.10",
-        # "3.11",
-        # "3.12",
-        # "3.13",
-        # "3.14",
-        "3.13t",
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
     ],
     "torch-version": [
         # "2.5.1",
@@ -67,15 +61,15 @@ LINUX_ARM64_MATRIX = {
         # "2.9.1",
         # "2.10.0",
         "2.11.0",
-        # "2.12.0",
+        "2.12.0",
     ],
     "cuda-version": [
         # "12.4",
-        # "12.6",
+        "12.6",
         "12.8",
         # "12.9",
-        # "13.0",
-        # "13.2",
+        "13.0",
+        "13.2",
     ],
 }
 
@@ -324,8 +318,8 @@ def main():
                 "linux": False,
                 # "linux": LINUX_MATRIX,
                 #
-                # "linux_arm64": False,
-                "linux_arm64": LINUX_ARM64_MATRIX,
+                "linux_arm64": False,
+                # "linux_arm64": LINUX_ARM64_MATRIX,
                 #
                 "linux_self_hosted": False,
                 # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
@@ -342,8 +336,8 @@ def main():
                 "windows": False,
                 # "windows": WINDOWS_MATRIX,
                 #
-                "windows_self_hosted": False,
-                # "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
+                # "windows_self_hosted": False,
+                "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
                 #
                 "windows_code_build": False,
                 # "windows_code_build": WINDOWS_CODEBUILD_MATRIX,


### PR DESCRIPTION
## Result

The ARM64 FA2 wheel that timed out at 6h in v0.9.34 (`2.8.3 × 3.13t × 2.11.0 × 12.8`) was **rebuilt successfully in v0.9.36 — 340 min, within the 6h limit** — after fixing the ccache nvcc wrapper (PR #118, `cicc: not found`).

| | value |
|---|---|
| ARM64 coverage | → **79.2%** |
| ARM64 FA2 | **0 missing (100%)** |
| ARM64 FA3 remaining | 30 (6 abi3 builds, 6h+ → larger runner later) |

Note: since the first run uses a cold cache, the within-6h finish is mainly GitHub-hosted ARM runner variance rather than ccache speedup. The lasting value is that the ccache mechanism now works (nvcc wrapper fixed) and the cache is populated for faster future rebuilds.

## Change

Restore `create_matrix.py` to `c6e3da7` (pre-retry):
- `LINUX_ARM64_MATRIX` → regular configuration
- `main()` → `linux_arm64` disabled, `windows_self_hosted` enabled

`build.yml` keeps `use-ccache: true` on the `linux_arm64` job (decision: keep ccache on for the slow ARM GitHub-hosted runners).

## Remaining

- **FA3 ARM64** — 30 missing / 6 abi3 builds, ~12-17h, needs a larger ARM runner or self-hosted.

🤖 Generated with Claude Code