### PR TITLE
chore(arm64): trial one FA3 build with ccache and a 5h45m build cap

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -77,7 +77,20 @@ runs:
         USE_CCACHE: ${{ inputs.use-ccache == 'true' && '1' || '0' }}
       run: |
         chmod +x build_linux.sh
-        ./build_linux.sh ${{ inputs.flash-attn-version }} ${{ inputs.python-version }} ${{ inputs.torch-version }} ${{ inputs.cuda-version }}
+        if [ "${USE_CCACHE}" = "1" ]; then
+          # Cap the build at 5h45m. GitHub-hosted jobs are hard-cancelled at
+          # 6h, which would skip the actions/cache save (post step) and lose
+          # the warm ccache. Stopping the build ourselves before that lets the
+          # cache be saved so a subsequent retry resumes from cached objects.
+          rc=0
+          timeout --signal=TERM 345m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
+          if [ "${rc}" = "124" ]; then
+            echo "::warning::Build hit the 5h45m cap; ccache will be saved for a warm retry. Marking this attempt as failed."
+          fi
+          exit "${rc}"
+        else
+          ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}"
+        fi
 
     - name: Locate wheel
       id: build_wheels

--- a/create_matrix.py
+++ b/create_matrix.py
@@ -40,36 +40,41 @@ LINUX_MATRIX = {
     ],
 }
 
+# Trial matrix: one FA3 ARM64 build with ccache + a 5h45m build cap, to
+# measure how far one GitHub-hosted run gets and whether the warm ccache is
+# saved for retries. FA3 is abi3, so a single build python (3.12) suffices.
+# Restore the original matrix after the trial.
 LINUX_ARM64_MATRIX = {
     "flash-attn-version": [
-        "2.6.3",
-        "2.7.4",
-        "2.8.3",
+        # "2.6.3",
+        # "2.7.4",
+        # "2.8.3",
+        FA3_COMMIT,
     ],
     "python-version": [
-        "3.10",
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
+        # "3.10",
+        # "3.11",
+        "3.12",  # FA3 is abi3 (cp39-abi3); one build covers all non-FT pythons
+        # "3.13",
+        # "3.14",
     ],
     "torch-version": [
         # "2.5.1",
         # "2.6.0",
         # "2.7.1",
         # "2.8.0",
-        # "2.9.1",
+        "2.9.1",
         # "2.10.0",
-        "2.11.0",
-        "2.12.0",
+        # "2.11.0",
+        # "2.12.0",
     ],
     "cuda-version": [
         # "12.4",
         "12.6",
-        "12.8",
+        # "12.8",
         # "12.9",
-        "13.0",
-        "13.2",
+        # "13.0",
+        # "13.2",
     ],
 }
 
@@ -318,8 +323,8 @@ def main():
                 "linux": False,
                 # "linux": LINUX_MATRIX,
                 #
-                "linux_arm64": False,
-                # "linux_arm64": LINUX_ARM64_MATRIX,
+                # "linux_arm64": False,
+                "linux_arm64": LINUX_ARM64_MATRIX,
                 #
                 "linux_self_hosted": False,
                 # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
@@ -336,8 +341,8 @@ def main():
                 "windows": False,
                 # "windows": WINDOWS_MATRIX,
                 #
-                # "windows_self_hosted": False,
-                "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
+                "windows_self_hosted": False,
+                # "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
                 #
                 "windows_code_build": False,
                 # "windows_code_build": WINDOWS_CODEBUILD_MATRIX,


### PR DESCRIPTION
## Goal

Probe whether **FA3 ARM64** can be built on GitHub-hosted runners across **ccache-warmed retries**. FA3 ARM64 runs ~12-17h on self-hosted hardware and has **zero GitHub-hosted history**, so a single 6h run cannot finish it. This run measures how far one capped run gets and whether the warm cache survives.

## Changes

- **build-and-upload action**: when `USE_CCACHE=1`, wrap the build in `timeout --signal=TERM 345m` (5h45m). GitHub **hard-cancels jobs at 6h, which skips the `actions/cache` save** and loses the warm cache. Capping at 5h45m stops the build ~15 min early so the post step can persist ccache for a warm retry. The cap exits 124 and fails the attempt on purpose.
- **create_matrix.py**: scope `LINUX_ARM64_MATRIX` to a single FA3 build — `fa3 × 3.12 × 2.9.1 × 12.6` (abi3, so one build python suffices); enable `linux_arm64`, disable `windows_self_hosted`.

## What this run tells us

1. **ninja [N/M] progress** reached in 5h45m → estimate how many retries FA3 needs.
2. Whether **`actions/cache` saves the warm ccache** after the self-imposed cap (the crux of the retry strategy).
3. ccache size via `ccache -s` → whether the 5G cap / 10G repo cache limit is a problem for FA3.

## After the trial

Restore the ARM64 matrix. If retries look viable, drive FA3 to completion via repeated warm-cache runs; otherwise fall back to a larger ARM runner.

🤖 Generated with Claude Code