### PR TITLE
fix(ccache): wrap FA3 bundled nvcc with ccache via setup.py patch

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -57,10 +57,10 @@ if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
   echo "Building $FLASH_ATTN_VARIANT (commit: $FA_COMMIT)"
   git clone https://github.com/Dao-AILab/flash-attention.git flash-attention
   git -C flash-attention checkout "$FA_COMMIT"
-  # Remove --resource-usage flag from upstream hopper/setup.py to suppress
-  # verbose ptxas info logs (register usage, stack frame, compile time)
-  # that clutter CI output with thousands of lines per build.
-  sed -i '/"--resource-usage"/d' flash-attention/hopper/setup.py
+  # Replace upstream hopper/setup.py with our patched version.
+  # The patch suppresses --resource-usage ptxas logs and adds ccache support
+  # for the bundled nvcc that FA3 downloads and injects via PYTORCH_NVCC.
+  cp "$(dirname "$0")/patches/fa3/setup.py" flash-attention/hopper/setup.py
 elif [[ "${FLASH_ATTN_VARIANT}" == "Flash Attention 2" ]]; then
   echo "Checking out flash-attention v${FLASH_ATTN_VERSION}..."
   git clone https://github.com/Dao-AILab/flash-attention.git flash-attention -b "v$FLASH_ATTN_VERSION"

--- a/patches/fa3/setup.py
+++ b/patches/fa3/setup.py
@@ -558,9 +558,27 @@ if not SKIP_CUDA_BUILD:
         # Need to append to path otherwise nvcc can't find cicc in nvvm/bin/cicc
         # nvcc 12.8 seems to hard-code looking for cicc in ../nvvm/bin/cicc
         os.environ["PATH"] = ctk_path_new + os.pathsep + os.environ["PATH"]
-        os.environ["PYTORCH_NVCC"] = nvcc_path_new
         # Make nvcc executable, sometimes after the copy it loses its permissions
         os.chmod(nvcc_path_new, os.stat(nvcc_path_new).st_mode | stat.S_IEXEC)
+        # Wrap bundled nvcc with ccache when USE_CCACHE=1 so that ccache hits
+        # apply to FA3 builds. Without this, setup.py sets PYTORCH_NVCC to the
+        # bundled binary directly, bypassing the system-nvcc ccache wrapper that
+        # build_linux.sh installs at /usr/local/cuda/bin/nvcc.
+        nvcc_real = nvcc_path_new + ".real"
+        if (
+            os.environ.get("USE_CCACHE") == "1"
+            and shutil.which("ccache")
+            and not os.path.exists(nvcc_real)
+        ):
+            os.rename(nvcc_path_new, nvcc_real)
+            with open(nvcc_path_new, "w") as f:
+                f.write(f'#!/usr/bin/env bash\nexec ccache "{nvcc_real}" "$@"\n')
+            os.chmod(nvcc_path_new, os.stat(nvcc_real).st_mode | stat.S_IEXEC)
+            os.environ["CCACHE_COMPILERTYPE"] = "nvcc"
+            print(f"ccache: wrapped bundled nvcc (real at {nvcc_real})")
+            os.environ["PYTORCH_NVCC"] = nvcc_path_new
+        else:
+            os.environ["PYTORCH_NVCC"] = nvcc_path_new
 
     cc_flag = []
     cc_flag.append("-gencode")


### PR DESCRIPTION
## Overview and Background

PR #121 made the warm ccache get saved on 5h45m cap, but the second-attempt build still spent the full 5h45m, only compiling 8 more files (219→227) than the first attempt. Investigation showed **ccache was completely bypassed on FA3 builds**.

FA3's `hopper/setup.py` downloads CUDA 12.6.85 nvcc at build time, places it under `third_party/nvidia/backend/bin/nvcc`, and sets `os.environ["PYTORCH_NVCC"]` to that bundled binary. PyTorch's `cpp_extension` then invokes that path directly — the ccache wrapper that `build_linux.sh` installs at `/usr/local/cuda/bin/nvcc` is never touched.

Because the override happens **inside** `setup.py`, no pre-build environment variable from `build_linux.sh` can prevent it. The fix has to live in the patched `setup.py` itself.

This PR also fixes a side issue: `build_linux.sh` was applying only a `sed` one-liner to upstream `hopper/setup.py` and never actually copying `patches/fa3/setup.py` over it, contrary to what `CLAUDE.md` documents.

## Related Issues

<!-- None -->

## Changes

- **`patches/fa3/setup.py`** — after the bundled nvcc is placed and `chmod`'d, if `USE_CCACHE=1` and `ccache` is on PATH, rename it to `nvcc.real` and write a small bash wrapper in its place that `exec ccache "$nvcc_real" "$@"`. Then point `PYTORCH_NVCC` at the wrapper and set `CCACHE_COMPILERTYPE=nvcc` so ccache treats the CUDA compiler correctly (ccache >= 4.4).
- **`build_linux.sh`** — replace the `sed -i '/"--resource-usage"/d'` one-liner with a full `cp "$(dirname "$0")/patches/fa3/setup.py" flash-attention/hopper/setup.py`. This activates the patched setup.py end-to-end (the `--resource-usage` removal is already part of the patched file) and is necessary for the bundled-nvcc ccache wrapping above to take effect.

## Test Instructions

- Trigger a Linux ARM64 FA3 test build with `use-ccache: true` (e.g. `fa3:e2743ab5…`, py3.12, torch 2.9.1, cu12.6).
- In the build log, look for `ccache: wrapped bundled nvcc (real at .../third_party/nvidia/backend/bin/nvcc.real)`.
- Re-run the same build to populate the cache, then trigger a third run and verify the ccache statistics at the end of the log show **non-zero hits** on the bundled nvcc, and that compilation reaches noticeably further (or completes) within the 5h45m cap.
