### PR TITLE
chore(ccache): add basedir/nohashdir + debug log to diagnose low hit rate

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -82,17 +82,15 @@ runs:
       run: |
         chmod +x build_linux.sh
         if [ "${USE_CCACHE}" = "1" ]; then
-          # Cap the build at 5h45m. GitHub-hosted jobs are hard-cancelled at
-          # 6h, which would skip the cache save and lose the warm ccache.
-          # Stopping the build ourselves before that lets the cache be saved
-          # so a subsequent retry resumes from cached objects.
+          # DEBUG: temporarily capped at 60m to inspect ccache hit/miss patterns.
+          # Original cap was 5h45m (= 345m); restore after debug.
           rc=0
-          timeout --signal=TERM 345m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
+          timeout --signal=TERM 60m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
           if [ "${rc}" = "124" ]; then
             # Capped: mark so the cache-save step below runs. A completed
             # build (rc=0) leaves capped unset, so its cache is NOT saved.
             echo "capped=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Build hit the 5h45m cap; ccache will be saved for a warm retry. Marking this attempt as failed."
+            echo "::warning::Build hit the 60m debug cap; ccache will be saved and the ccache debug log will be uploaded as an artifact."
           fi
           exit "${rc}"
         else
@@ -107,6 +105,29 @@ runs:
       with:
         path: ~/.ccache
         key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
+
+    # DEBUG: dump ccache statistics and config, then upload the per-call debug
+    # log so we can diagnose why hit rate is low. Remove after debug.
+    - name: Dump ccache stats and config
+      if: ${{ always() && inputs.use-ccache == 'true' }}
+      shell: bash
+      run: |
+        echo "=== ccache -s (statistics) ==="
+        ccache -s || true
+        echo "=== ccache -p (config) ==="
+        ccache -p || true
+        echo "=== ccache debug log size ==="
+        ls -lh "$HOME/ccache-debug.log" 2>/dev/null || echo "no debug log"
+
+    - name: Upload ccache debug artifacts
+      if: ${{ always() && inputs.use-ccache == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ccache-debug-${{ inputs.flash-attn-version }}-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}
+        path: |
+          ~/ccache-debug.log
+        if-no-files-found: warn
+        retention-days: 7
 
     - name: Locate wheel
       id: build_wheels

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -120,7 +120,18 @@ if [[ "${USE_CCACHE:-0}" == "1" ]]; then
     export CCACHE_MAXSIZE="${CCACHE_MAXSIZE:-5G}"
     # Hash only file content, not mtime/path, so cache hits survive fresh clones.
     export CCACHE_COMPILERCHECK="${CCACHE_COMPILERCHECK:-content}"
+    # Normalize absolute paths under the build tree to relative paths so cache
+    # entries survive across GitHub-hosted runners (different VM hostnames,
+    # paths, etc.). Without this, nvcc command lines embed absolute paths and
+    # ccache treats every invocation as a miss.
+    export CCACHE_BASEDIR="${CCACHE_BASEDIR:-$(pwd)}"
+    export CCACHE_NOHASHDIR=1
+    # Debug log for ccache hit/miss analysis. Written to a path the CI step
+    # can upload as an artifact.
+    export CCACHE_LOGFILE="${CCACHE_LOGFILE:-$HOME/ccache-debug.log}"
     ccache -M "$CCACHE_MAXSIZE" >/dev/null 2>&1 || true
+    echo "ccache: CCACHE_BASEDIR=$CCACHE_BASEDIR CCACHE_NOHASHDIR=$CCACHE_NOHASHDIR"
+    echo "ccache: CCACHE_LOGFILE=$CCACHE_LOGFILE"
 
     # Host compiler (gcc/g++): use ccache's masquerade dir on PATH so that
     # tools resolving the compiler by name go through ccache.


### PR DESCRIPTION
## Overview and Background

v0.9.38 attempt 2 restored the 932 MB warm ccache from attempt 1 but only advanced compilation by **7 units (218 → 225/293)** over the full 5h45m cap. The ccache size still grew (+317 MB), which means ccache *was* storing entries but almost none of them were hits — every nvcc invocation looked unique.

**Suspected cause**: nvcc command lines embed absolute paths (`/home/runner/work/...`, include dirs, etc.). GitHub-hosted runners may also vary in hostname or other path-like state. Without `CCACHE_BASEDIR`/`CCACHE_NOHASHDIR`, those absolute paths land in the hash inputs and ccache treats every call as a miss.

This is a **temporary debug PR** that adds path normalization plus a per-call debug log, with a 60-minute build cap so the diagnostic loop finishes in ~1 hour. We'll inspect `ccache -s` and the artifact, then revert.

## Related Issues

<!-- None -->

## Changes

- **`build_linux.sh`** — when `USE_CCACHE=1`:
  - `CCACHE_BASEDIR=$(pwd)` + `CCACHE_NOHASHDIR=1` so absolute paths inside the build tree are normalized to relative paths in the cache key
  - `CCACHE_LOGFILE=$HOME/ccache-debug.log` for per-call hit/miss tracing
  - log the new vars at startup so they're visible in the build log
- **`action.yml`** — debug-only:
  - lower `timeout` from `345m` to `60m`
  - new step: `Dump ccache stats and config` runs `ccache -s` and `ccache -p` at the end
  - new step: `Upload ccache debug artifacts` uploads `~/ccache-debug.log` so we can analyze hit/miss patterns offline
- All changes are tagged `DEBUG` in comments and will be reverted after analysis.

## Test Instructions

1. Merge this PR.
2. Trigger a `linux-arm64` test build with `use-ccache: true` (`fa3:e2743ab5…, py3.12, torch 2.9.1, cu12.6`).
3. After ~1h the cap fires, the cache is saved, and the artifact is uploaded.
4. Inspect:
   - The build log for `ccache -s` (Hit/Miss counts, ratio)
   - The `ccache-debug-...` artifact for per-call traces explaining which inputs caused misses
5. If `CCACHE_BASEDIR`/`CCACHE_NOHASHDIR` alone fix the hit rate, drop the debug log and restore the 345m cap in a follow-up. Otherwise the artifact reveals what to tune next.
