### PR TITLE
chore(ccache): upgrade to ccache 4.10.2 to fix nvcc uncacheable rate

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -58,8 +58,51 @@ runs:
       if: ${{ inputs.use-ccache == 'true' }}
       shell: bash
       run: |
+        # Ubuntu 22.04 ships ccache 4.5.1, which mishandles nvcc's
+        # --generate-dependencies-with-compile flag — debug logs showed
+        # 82% of nvcc invocations classified as 'called_for_preprocessing'
+        # (uncacheable). 4.10+ properly handles this. No official aarch64
+        # prebuilt exists, so build from source (~2 min).
+        CCACHE_VERSION=4.10.2
         sudo apt-get update
-        sudo apt-get install -y ccache
+        # apt's ccache provides /usr/lib/ccache/{gcc,g++,...} masquerade
+        # symlinks that point to /usr/bin/ccache. build_linux.sh prepends
+        # /usr/lib/ccache to PATH to route host compiler calls through
+        # ccache, so we keep the symlinks and replace /usr/bin/ccache
+        # below with the upgraded binary.
+        sudo apt-get install -y ccache cmake libzstd-dev
+        tmp=$(mktemp -d)
+        BIN=""
+        case "$(uname -m)" in
+          x86_64)  ARCH=x86_64 ;;
+          aarch64) ARCH=aarch64 ;;
+          *)       ARCH="" ;;
+        esac
+        if [ -n "$ARCH" ]; then
+          url="https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-linux-${ARCH}.tar.xz"
+          echo "trying prebuilt: $url"
+          if curl -fL "$url" -o "$tmp/ccache.tar.xz" 2>/dev/null; then
+            tar -xJf "$tmp/ccache.tar.xz" -C "$tmp"
+            BIN="$tmp/ccache-${CCACHE_VERSION}-linux-${ARCH}/ccache"
+          fi
+        fi
+        if [ -z "$BIN" ] || [ ! -x "$BIN" ]; then
+          echo "no prebuilt; building from source"
+          curl -fL "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}.tar.xz" -o "$tmp/src.tar.xz"
+          tar -xJf "$tmp/src.tar.xz" -C "$tmp"
+          cmake -S "$tmp/ccache-${CCACHE_VERSION}" -B "$tmp/build" \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DENABLE_TESTING=OFF \
+                -DENABLE_DOCUMENTATION=OFF \
+                -DREDIS_STORAGE_BACKEND=OFF
+          cmake --build "$tmp/build" -j "$(nproc)"
+          BIN="$tmp/build/ccache"
+        fi
+        sudo install -m755 "$BIN" /usr/local/bin/ccache
+        sudo install -m755 "$BIN" /usr/bin/ccache
+        rm -rf "$tmp"
+        echo "=== installed ccache version ==="
+        ccache --version | head -1
 
     # Restore only here. Saving is done by a separate step that runs ONLY when
     # the build was capped at 5h45m (a completed build needs no warm cache).


### PR DESCRIPTION
## Why

Debug runs from PR #123/#124 showed ccache 4.5.1 (Ubuntu 22.04 standard) reports **82% of nvcc invocations as 'called_for_preprocessing' (uncacheable)**. Sample log summary:

| Count | Result |
|---|---|
| 80 | `called_for_preprocessing` |
| 50 | `primary_storage_miss` / `direct_cache_miss` |
| 26 | `preprocessor_error` |
| 24 | `cache_miss` |
| 24 | `Disabling direct mode` |
| **1** | `direct_cache_hit` |

The root cause is ccache 4.5.1's mishandling of nvcc's `--generate-dependencies-with-compile` flag — it treats the compile-and-dep-gen call as a preprocessor-only invocation and skips caching. ccache 4.10+ added proper support.

## What

- Keep `apt-get install ccache` to preserve `/usr/lib/ccache/` masquerade symlinks (build_linux.sh prepends that dir to PATH for host compiler routing)
- Replace `/usr/bin/ccache` (the symlinks' target) and `/usr/local/bin/ccache` with ccache 4.10.2
- Try the official prebuilt for the runner's arch; fall back to a CMake source build (~2 min) for arches without prebuilts (aarch64)
- Source build uses `-DENABLE_TESTING=OFF -DENABLE_DOCUMENTATION=OFF -DREDIS_STORAGE_BACKEND=OFF` to minimize dependencies

## Test plan

The 60m debug cap from #123/#124 is still active. After merge, trigger a Linux ARM64 test build with `use-ccache: true` and inspect the `ccache -s` output + log summary at the end. Expected: 'Uncacheable' should drop dramatically, hit rate on a populated cache should be much higher than 1/76. If confirmed, follow up by reverting the 60m cap and the debug log instrumentation.