### PR TITLE
chore(ccache): remove ccache entirely; rename use-ccache -> use-build-cache

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -22,8 +22,8 @@ inputs:
     description: "Whether to clean up Python installation"
     required: false
     default: "false"
-  use-ccache:
-    description: "Whether to use ccache to speed up compilation"
+  use-build-cache:
+    description: "Whether to cache the ninja build directory across retries and cap builds at 5h45m so the warm cache survives a hard 6h cancel."
     required: false
     default: "false"
 
@@ -54,35 +54,15 @@ runs:
       with:
         version: ${{ inputs.cuda-version }}
 
-    - name: Install ccache
-      if: ${{ inputs.use-ccache == 'true' }}
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ccache
-
-    # Restore only here. Saving is done by a separate step that runs ONLY when
-    # the build was capped at 5h45m (a completed build needs no warm cache).
-    - name: Restore ccache
-      id: ccache_restore
-      if: ${{ inputs.use-ccache == 'true' }}
-      uses: actions/cache/restore@v4
-      with:
-        path: ~/.ccache
-        key: ccache-linux-${{ runner.arch }}-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}-fa${{ inputs.flash-attn-version }}-${{ github.run_id }}-${{ github.run_attempt }}
-        restore-keys: |
-          ccache-linux-${{ runner.arch }}-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}-fa${{ inputs.flash-attn-version }}-
-          ccache-linux-${{ runner.arch }}-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}-
-
-    # ninja build directory cache. Unlike ccache (which keys on per-call
-    # hashes), this cache stores the entire flash-attention/hopper/build/
-    # tree under ~/.fa-build-cache/ so ninja sees the .o files on the next
-    # attempt and skips already-compiled translation units. ccache 4.5.1
-    # marks 97% of FA3 nvcc calls 'uncacheable' (--generate-dependencies-with-compile),
-    # so build-dir caching is the only reliable way to make retries faster.
+    # ninja build directory cache. Stores the entire
+    # flash-attention/hopper/build/ tree under ~/.fa-build-cache/ so ninja
+    # sees the .o files on the next attempt and skips already-compiled
+    # translation units. (ccache was attempted previously but FA3's nvcc
+    # invocations are 97% 'uncacheable' from ccache's perspective due to
+    # --generate-dependencies-with-compile.)
     - name: Restore FA3 build directory cache
       id: build_cache_restore
-      if: ${{ inputs.use-ccache == 'true' }}
+      if: ${{ inputs.use-build-cache == 'true' }}
       uses: actions/cache/restore@v4
       with:
         path: ~/.fa-build-cache
@@ -94,13 +74,13 @@ runs:
       id: build
       shell: bash
       env:
-        USE_CCACHE: ${{ inputs.use-ccache == 'true' && '1' || '0' }}
+        USE_BUILD_CACHE: ${{ inputs.use-build-cache == 'true' && '1' || '0' }}
       run: |
         chmod +x build_linux.sh
-        if [ "${USE_CCACHE}" = "1" ]; then
+        if [ "${USE_BUILD_CACHE}" = "1" ]; then
           # Cap the build at 5h45m. GitHub-hosted jobs are hard-cancelled at
-          # 6h, which would skip the cache save and lose the warm caches.
-          # Stopping the build ourselves before that lets the caches be saved
+          # 6h, which would skip the cache save and lose the warm build dir.
+          # Stopping the build ourselves before that lets the cache be saved
           # so a subsequent retry resumes from the warm build directory.
           rc=0
           timeout --signal=TERM 345m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
@@ -108,7 +88,7 @@ runs:
             # Capped: mark so the cache-save steps below run. A completed
             # build (rc=0) leaves capped unset, so its cache is NOT saved.
             echo "capped=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Build hit the 5h45m cap; build directory and ccache will be saved for a warm retry. Marking this attempt as failed."
+            echo "::warning::Build hit the 5h45m cap; build directory will be saved for a warm retry. Marking this attempt as failed."
           fi
           exit "${rc}"
         else
@@ -119,7 +99,7 @@ runs:
     # actions/cache/save can pick it up at a stable path.
     - name: Stage FA3 build directory for cache save
       id: stage_build
-      if: ${{ always() && inputs.use-ccache == 'true' && steps.build.outputs.capped == 'true' }}
+      if: ${{ always() && inputs.use-build-cache == 'true' && steps.build.outputs.capped == 'true' }}
       shell: bash
       run: |
         src=""
@@ -141,20 +121,11 @@ runs:
         fi
 
     - name: Save FA3 build directory cache (only when capped)
-      if: ${{ always() && inputs.use-ccache == 'true' && steps.build.outputs.capped == 'true' && steps.stage_build.outputs.staged == 'true' }}
+      if: ${{ always() && inputs.use-build-cache == 'true' && steps.build.outputs.capped == 'true' && steps.stage_build.outputs.staged == 'true' }}
       uses: actions/cache/save@v4
       with:
         path: ~/.fa-build-cache
         key: ${{ steps.build_cache_restore.outputs.cache-primary-key }}
-
-    # Save the warm ccache ONLY when the build was capped (not on success).
-    # always() lets this run even though the capped build step exited non-zero.
-    - name: Save ccache (only when capped)
-      if: ${{ always() && inputs.use-ccache == 'true' && steps.build.outputs.capped == 'true' }}
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.ccache
-        key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
 
     - name: Locate wheel
       id: build_wheels

--- a/.github/workflows/_build_linux.yml
+++ b/.github/workflows/_build_linux.yml
@@ -33,8 +33,8 @@ on:
         required: false
         type: boolean
         default: true
-      use-ccache:
-        description: "Whether to use ccache to speed up compilation"
+      use-build-cache:
+        description: "Whether to cache the ninja build directory across retries"
         required: false
         type: boolean
         default: false
@@ -71,4 +71,4 @@ jobs:
           torch-version: ${{ inputs.torch-version }}
           cuda-version: ${{ inputs.cuda-version }}
           is-upload: ${{ inputs.is-upload }}
-          use-ccache: ${{ inputs.use-ccache }}
+          use-build-cache: ${{ inputs.use-build-cache }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       torch-version: ${{ matrix.torch-version }}
       cuda-version: ${{ matrix.cuda-version }}
       runner: "ubuntu-22.04-arm"
-      use-ccache: true
+      use-build-cache: true
     secrets: inherit
 
   # ################ Self-hosted runner ################

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -55,8 +55,8 @@ on:
         description: "NVCC_THREADS (optional, overrides auto-detection)"
         required: false
         type: string
-      use-ccache:
-        description: "Use ccache to speed up compilation (GitHub-hosted Linux only)"
+      use-build-cache:
+        description: "Cache the ninja build directory across retries and cap builds at 5h45m (GitHub-hosted Linux only)"
         required: false
         type: boolean
         default: false
@@ -104,7 +104,7 @@ jobs:
       cuda-version: ${{ inputs.cuda-version }}
       is-upload: false
       runner: ubuntu-22.04-arm
-      use-ccache: ${{ inputs.use-ccache }}
+      use-build-cache: ${{ inputs.use-build-cache }}
 
   # #########################################################
   # Linux ARM64 self-hosted runner

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -57,9 +57,9 @@ if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
   echo "Building $FLASH_ATTN_VARIANT (commit: $FA_COMMIT)"
   git clone https://github.com/Dao-AILab/flash-attention.git flash-attention
   git -C flash-attention checkout "$FA_COMMIT"
-  # Replace upstream hopper/setup.py with our patched version.
-  # The patch suppresses --resource-usage ptxas logs and adds ccache support
-  # for the bundled nvcc that FA3 downloads and injects via PYTORCH_NVCC.
+  # Replace upstream hopper/setup.py with our patched version, which
+  # suppresses verbose --resource-usage ptxas logs that would otherwise
+  # clutter CI output with thousands of lines per build.
   cp "$(dirname "$0")/patches/fa3/setup.py" flash-attention/hopper/setup.py
   # If a previous attempt's ninja build directory was cached by the CI step
   # (Restore FA3 build directory cache), move it into place so ninja sees
@@ -123,57 +123,6 @@ echo "Build parallelism settings:"
 echo "  MAX_JOBS: $MAX_JOBS"
 echo "  NVCC_THREADS: $NVCC_THREADS"
 
-# Optional ccache setup (enabled with USE_CCACHE=1).
-# Speeds up rebuilds by caching compiled objects. Useful for retrying builds
-# that hit the GitHub-hosted 6h limit: the second run reuses cached objects.
-if [[ "${USE_CCACHE:-0}" == "1" ]]; then
-  if command -v ccache >/dev/null 2>&1; then
-    echo "ccache: enabled"
-    export CCACHE_DIR="${CCACHE_DIR:-$HOME/.ccache}"
-    export CCACHE_MAXSIZE="${CCACHE_MAXSIZE:-5G}"
-    # Hash only file content, not mtime/path, so cache hits survive fresh clones.
-    export CCACHE_COMPILERCHECK="${CCACHE_COMPILERCHECK:-content}"
-    # Normalize absolute paths under the build tree to relative paths so cache
-    # entries survive across GitHub-hosted runners (different VM hostnames,
-    # paths, etc.). Without this, nvcc command lines embed absolute paths and
-    # ccache treats every invocation as a miss.
-    export CCACHE_BASEDIR="${CCACHE_BASEDIR:-$(pwd)}"
-    export CCACHE_NOHASHDIR=1
-    ccache -M "$CCACHE_MAXSIZE" >/dev/null 2>&1 || true
-
-    # Host compiler (gcc/g++): use ccache's masquerade dir on PATH so that
-    # tools resolving the compiler by name go through ccache.
-    if [ -d /usr/lib/ccache ]; then
-      export PATH="/usr/lib/ccache:$PATH"
-    fi
-
-    # nvcc: PyTorch's cpp_extension invokes $CUDA_HOME/bin/nvcc by absolute
-    # path, so PATH masquerade does not apply. Replace nvcc with a wrapper that
-    # routes through ccache. The real binary MUST stay in the same bin dir
-    # (renamed nvcc.real), otherwise nvcc cannot locate its sibling tools
-    # (cicc, ptxas, nvvm) by relative path and fails with "cicc: not found".
-    NVCC_BIN=$(command -v nvcc || true)
-    if [ -n "$NVCC_BIN" ]; then
-      NVCC_DIR=$(dirname "$NVCC_BIN")
-      if [ ! -f "$NVCC_DIR/nvcc.real" ]; then
-        sudo mv "$NVCC_BIN" "$NVCC_DIR/nvcc.real"
-        sudo tee "$NVCC_BIN" >/dev/null <<EOF
-#!/usr/bin/env bash
-exec ccache "$NVCC_DIR/nvcc.real" "\$@"
-EOF
-        sudo chmod +x "$NVCC_BIN"
-        echo "ccache: wrapped nvcc (real at $NVCC_DIR/nvcc.real)"
-      fi
-      # The real binary's basename is "nvcc.real", so tell ccache explicitly
-      # that this is the CUDA compiler (ccache >= 4.4 supports CCACHE_COMPILERTYPE).
-      export CCACHE_COMPILERTYPE=nvcc
-    fi
-    ccache -z >/dev/null 2>&1 || true
-  else
-    echo "ccache: USE_CCACHE=1 but ccache not found on PATH; building without it"
-  fi
-fi
-
 # Build wheels
 echo "Building wheels..."
 if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
@@ -190,9 +139,3 @@ NVCC_THREADS=$NVCC_THREADS MAX_JOBS=$MAX_JOBS \
   time python setup.py bdist_wheel --dist-dir=dist
 wheel_name=$(basename $(ls dist/*.whl | head -n 1))
 echo "Built wheel: $wheel_name"
-
-# Report ccache statistics (hit/miss) when enabled.
-if [[ "${USE_CCACHE:-0}" == "1" ]] && command -v ccache >/dev/null 2>&1; then
-  echo "=== ccache statistics ==="
-  ccache -s || true
-fi

--- a/patches/fa3/setup.py
+++ b/patches/fa3/setup.py
@@ -558,27 +558,9 @@ if not SKIP_CUDA_BUILD:
         # Need to append to path otherwise nvcc can't find cicc in nvvm/bin/cicc
         # nvcc 12.8 seems to hard-code looking for cicc in ../nvvm/bin/cicc
         os.environ["PATH"] = ctk_path_new + os.pathsep + os.environ["PATH"]
+        os.environ["PYTORCH_NVCC"] = nvcc_path_new
         # Make nvcc executable, sometimes after the copy it loses its permissions
         os.chmod(nvcc_path_new, os.stat(nvcc_path_new).st_mode | stat.S_IEXEC)
-        # Wrap bundled nvcc with ccache when USE_CCACHE=1 so that ccache hits
-        # apply to FA3 builds. Without this, setup.py sets PYTORCH_NVCC to the
-        # bundled binary directly, bypassing the system-nvcc ccache wrapper that
-        # build_linux.sh installs at /usr/local/cuda/bin/nvcc.
-        nvcc_real = nvcc_path_new + ".real"
-        if (
-            os.environ.get("USE_CCACHE") == "1"
-            and shutil.which("ccache")
-            and not os.path.exists(nvcc_real)
-        ):
-            os.rename(nvcc_path_new, nvcc_real)
-            with open(nvcc_path_new, "w") as f:
-                f.write(f'#!/usr/bin/env bash\nexec ccache "{nvcc_real}" "$@"\n')
-            os.chmod(nvcc_path_new, os.stat(nvcc_real).st_mode | stat.S_IEXEC)
-            os.environ["CCACHE_COMPILERTYPE"] = "nvcc"
-            print(f"ccache: wrapped bundled nvcc (real at {nvcc_real})")
-            os.environ["PYTORCH_NVCC"] = nvcc_path_new
-        else:
-            os.environ["PYTORCH_NVCC"] = nvcc_path_new
 
     cc_flag = []
     cc_flag.append("-gencode")


### PR DESCRIPTION
## Why

PRs #123-#126 confirmed ccache is the wrong tool for FA3 retries: 97% of nvcc invocations are flagged uncacheable due to `--generate-dependencies-with-compile`. PR #126 introduced a ninja build-directory cache that supersedes ccache for the warm-retry use case, but left the ccache plumbing in place "just in case host C++ hits help". Debug stats showed they don't, so drop ccache entirely instead of carrying dead code.

## What changes

**action.yml**
- Remove the `Install ccache` apt step
- Remove the `Restore ccache` / `Save ccache (only when capped)` actions/cache steps
- Rename the input `use-ccache` → `use-build-cache` (its actual purpose now is to gate the build-directory cache and the 5h45m cap)
- Rename the corresponding env var `USE_CCACHE` → `USE_BUILD_CACHE`

**workflows/{test-build,_build_linux,build}.yml**
- Propagate the input/parameter rename

**build_linux.sh**
- Remove the entire ccache setup block (`CCACHE_*` env, `ccache -M/-z`, `/usr/lib/ccache` PATH masquerade, nvcc → ccache wrapper script)
- Remove the trailing `ccache -s` stats dump

**patches/fa3/setup.py**
- Drop the bundled-nvcc ccache wrapper, so `PYTORCH_NVCC` simply points at the downloaded nvcc again

## Test plan

After merge, trigger a Linux ARM64 test build with `use-build-cache: true`. The first attempt should hit the 5h45m cap and save `~/.fa-build-cache/build` (no more ccache directory in the run). A retry should restore that directory and advance much further (or complete).