### PR TITLE
fix(build-cache): force header/source mtime to the past so ninja skips .o

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -64,15 +64,37 @@ if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
   # If a previous attempt's ninja build directory was cached by the CI step
   # (Restore FA3 build directory cache), move it into place so ninja sees
   # the existing .o files and skips already-compiled translation units.
-  # Touch every file so ninja considers them newer than the freshly cloned
-  # .cu sources (otherwise mtime would force recompilation).
+  #
+  # mtime fixup: ninja decides to rebuild a .o when ANY header/source it
+  # depends on (recorded in the .o.d depfile) has a newer mtime than the .o.
+  # In CI, the venv (torch headers), CUDA toolkit and the freshly cloned
+  # flash-attention sources all have mtime = "now", which would force ninja
+  # to rebuild everything. Push every relevant input far into the past, then
+  # re-touch the restored .o files to "now", so the comparison favors skip.
   if [ -d "$HOME/.fa-build-cache/build" ]; then
     echo "fa-build-cache: restoring previous ninja build directory"
     du -sh "$HOME/.fa-build-cache/build" || true
     mkdir -p flash-attention/hopper
     rm -rf flash-attention/hopper/build
     mv "$HOME/.fa-build-cache/build" flash-attention/hopper/build
+    PAST=197001020000
+    # FA3 sources + vendored cutlass / cute / etc. Exclude the build dir so
+    # we don't downgrade the .o files we are about to re-touch.
+    find flash-attention -path flash-attention/hopper/build -prune -o -type f -print 2>/dev/null \
+      | xargs -r touch -t "$PAST" 2>/dev/null || true
+    # torch + python headers inside the venv
+    if [ -d .venv ]; then
+      find .venv/lib -path '*/site-packages/torch/include*' -type f \
+        -exec touch -t "$PAST" {} + 2>/dev/null || true
+    fi
+    # CUDA toolkit headers (sudo since /usr/local/cuda is root-owned)
+    if [ -d /usr/local/cuda/include ]; then
+      sudo find /usr/local/cuda/include -type f \
+        -exec touch -t "$PAST" {} + 2>/dev/null || true
+    fi
+    # Mark the .o tree as "now" — newer than every header/source above.
     find flash-attention/hopper/build -exec touch {} + 2>/dev/null || true
+    echo "fa-build-cache: mtime fixup done (sources/headers -> $PAST, .o -> now)"
   fi
 elif [[ "${FLASH_ATTN_VARIANT}" == "Flash Attention 2" ]]; then
   echo "Checking out flash-attention v${FLASH_ATTN_VERSION}..."


### PR DESCRIPTION
## Why

PR #126 cached `flash-attention/hopper/build/` across retries, but in the validation run (#27055234967) ninja **rebuilt every translation unit from scratch (1/293 → 210/293)** despite a successful cache restore.

Root cause: in a fresh GitHub-hosted VM the freshly cloned sources, the uv-installed torch headers and the setup-cuda CUDA toolkit headers all have mtime = 'now'. The restored .o files are older even after `touch`. ninja consults the per-target depfile (`.o.d`) and any header newer than its .o triggers a rebuild.

## What changes

Touch every header/source the .o files depend on to a fixed point far in the past (`1970-01-02`), then re-touch the .o tree so it ends up at 'now'. That keeps the inputs strictly older than the outputs and lets ninja prove the restored .o files are up-to-date.

- `flash-attention/` (all sources + vendored cutlass), excluding the build directory itself
- `.venv/lib/.../site-packages/torch/include` (torch headers)
- `/usr/local/cuda/include` (CUDA toolkit headers, requires sudo)

## Test plan

Trigger a Linux ARM64 test build with `use-build-cache: true` for `fa3:e2743ab5…, py3.12, torch 2.9.1, cu12.6`. The previous run left a 293 MB cache (`fabuild-...-27055234967-1`, ended at 210/293). On restore-key hit, ninja should report 209 .o files as up-to-date and start the next compile near 211/293 within a few minutes — confirming the mtime fixup works. If ninja still rebuilds from 1/293, inspect with `ninja -d explain` to see which header is still ahead.