### PR TITLE
chore(build-cache): debug why ninja still rebuilds restored .o files

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -78,17 +78,13 @@ runs:
       run: |
         chmod +x build_linux.sh
         if [ "${USE_BUILD_CACHE}" = "1" ]; then
-          # Cap the build at 5h45m. GitHub-hosted jobs are hard-cancelled at
-          # 6h, which would skip the cache save and lose the warm build dir.
-          # Stopping the build ourselves before that lets the cache be saved
-          # so a subsequent retry resumes from the warm build directory.
+          # DEBUG: temporarily capped at 60m to diagnose ninja rebuild reasons.
+          # Original cap is 5h45m (= 345m). Restore after debug.
           rc=0
-          timeout --signal=TERM 345m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
+          timeout --signal=TERM 60m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
           if [ "${rc}" = "124" ]; then
-            # Capped: mark so the cache-save steps below run. A completed
-            # build (rc=0) leaves capped unset, so its cache is NOT saved.
             echo "capped=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Build hit the 5h45m cap; build directory will be saved for a warm retry. Marking this attempt as failed."
+            echo "::warning::Build hit the 60m debug cap."
           fi
           exit "${rc}"
         else

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -95,6 +95,40 @@ if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
     # Mark the .o tree as "now" — newer than every header/source above.
     find flash-attention/hopper/build -exec touch {} + 2>/dev/null || true
     echo "fa-build-cache: mtime fixup done (sources/headers -> $PAST, .o -> now)"
+    # DEBUG: dump ninja state and ask ninja itself why it would rebuild.
+    BUILD_TEMP=flash-attention/hopper/build/temp.linux-aarch64-cpython-312
+    echo "=== DEBUG: ninja state under $BUILD_TEMP ==="
+    if [ -d "$BUILD_TEMP" ]; then
+      echo "--- ls -la (top-level):"
+      ls -la "$BUILD_TEMP" | head -20 || true
+      echo "--- ls -la (instantiations/) sample:"
+      ls -la "$BUILD_TEMP/instantiations" 2>/dev/null | head -10 || true
+      echo "--- build.ninja:"
+      ls -la "$BUILD_TEMP/build.ninja" 2>/dev/null || echo "  missing"
+      echo "--- .ninja_log:"
+      ls -la "$BUILD_TEMP/.ninja_log" 2>/dev/null || echo "  missing"
+      [ -f "$BUILD_TEMP/.ninja_log" ] && head -20 "$BUILD_TEMP/.ninja_log"
+      echo "--- .ninja_deps:"
+      ls -la "$BUILD_TEMP/.ninja_deps" 2>/dev/null || echo "  missing"
+      echo "--- representative mtimes (.o, .cpp, torch.h, cuda.h):"
+      stat -c '%y %n' "$BUILD_TEMP/flash_api_stable.o" 2>/dev/null || echo "  no .o"
+      stat -c '%y %n' flash-attention/hopper/flash_api_stable.cpp 2>/dev/null || echo "  no .cpp"
+      ls .venv/lib/python*/site-packages/torch/include/torch/torch.h 2>/dev/null \
+        | head -1 | xargs -r stat -c '%y %n' || echo "  no torch.h"
+      stat -c '%y %n' /usr/local/cuda/include/cuda.h 2>/dev/null || echo "  no cuda.h"
+      # Ask ninja to dry-run and explain.
+      uv pip install --quiet ninja 2>/dev/null || true
+      if command -v ninja >/dev/null && [ -f "$BUILD_TEMP/build.ninja" ]; then
+        echo "--- ninja --version: $(ninja --version 2>/dev/null || true)"
+        echo "--- ninja -d explain -n (first 80 lines):"
+        (cd "$BUILD_TEMP" && ninja -d explain -n 2>&1) | head -80 || true
+      else
+        echo "--- ninja not available or build.ninja missing"
+      fi
+    else
+      echo "  $BUILD_TEMP does not exist"
+    fi
+    echo "=== END DEBUG ==="
   fi
 elif [[ "${FLASH_ATTN_VARIANT}" == "Flash Attention 2" ]]; then
   echo "Checking out flash-attention v${FLASH_ATTN_VERSION}..."


### PR DESCRIPTION
PR #128 lowered every header/source mtime to 1970-01-02 and bumped the restored .o tree to 'now', expecting ninja to skip the 209 already-built translation units in the restored cache (`fabuild-...-27055234967-1`, 293 MB). It did not — the next test build started compiling from [1/293] anyway.

Add a diagnostic block immediately after the mtime fixup so we can see, in a single 60m run, exactly why ninja considers each .o dirty:

- `ls -la` of the build temp dir (top level + instantiations/)
- `ls -la` + `head -20` of `.ninja_log`, `.ninja_deps`, `build.ninja` to confirm ninja state survived restore
- `stat -c '%y %n'` on a representative .o, .cpp, torch.h, cuda.h to verify mtime ordering is actually 'header < .o'
- `uv pip install ninja` + `ninja -d explain -n` (dry-run) inside the build dir — explain names the exact dirty input for each output, so the rebuild reason is unambiguous

action.yml: drop the cap from 345m to 60m so we get diagnostic output within ~1h; restore after debug.