### PR TITLE
fix(build-cache): drop .ninja_deps so header touch doesn't trigger rebuild

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -98,7 +98,15 @@ if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
     # forces a full rebuild. actions/cache@v4 uses tar, which preserves
     # mtime, so the restored .o files already have the timestamps that
     # match the deps info recorded by the previous attempt.
-    echo "fa-build-cache: mtime fixup done (sources/headers -> $PAST, .o tree untouched)"
+    #
+    # Drop .ninja_deps too: it stores per-header mtimes from the previous
+    # build, and our 1970 touch of cutlass/torch/CUDA headers makes every
+    # entry mismatch ("ninja explain: header is dirty"). ninja can recover
+    # the same dep graph from the per-target .o.d files (gcc-style depfiles
+    # that are part of the build directory) on its next pass, while the
+    # 'output.o > input.h' mtime check now correctly says 'up to date'.
+    rm -f "flash-attention/hopper/build/temp.linux-aarch64-cpython-312/.ninja_deps"
+    echo "fa-build-cache: mtime fixup done (sources/headers -> $PAST, .o tree untouched, .ninja_deps dropped)"
     # DEBUG: dump ninja state + ask ninja itself why it would rebuild.
     # Remove this block once we confirm the fix.
     BUILD_TEMP=flash-attention/hopper/build/temp.linux-aarch64-cpython-312


### PR DESCRIPTION
## Why

PR #130 stopped touching .o files, but the next 60m debug run (#27079771899) still rebuilt every translation unit. `ninja -d explain -n` named a new offender:

```
ninja explain: cutlass/include/cutlass/numeric_types.h is dirty
ninja explain: cute/util/type_traits.hpp is dirty
...
```

ninja's `.ninja_deps` stores, for each output, the mtime of every header it depended on during the previous build. On restore those headers (cutlass under `flash-attention/`, plus torch and CUDA includes) all have fresh 'now' or '1970' mtimes — because they live outside the cached `~/.fa-build-cache/build/` — so every recorded mtime mismatches and ninja marks the header (and therefore every dependent .o) dirty.

## Fix

Delete `.ninja_deps` after restore. ninja regenerates the same graph from the per-target `.o.d` files (gcc-style depfiles stored alongside the .o under `flash-attention/hopper/build/temp.linux-aarch64-cpython-312/`), and the plain 'output.o newer than input.h' mtime check then correctly says 'up to date' for every restored translation unit.

We keep the 1970 touch of cutlass/torch/CUDA headers so the .o mtimes (preserved by `actions/cache@v4` tar) stay strictly newer than the inputs.

## Test plan

Re-run the 60m debug build. `ninja -d explain -n` should print no rebuild reasons, and the compile sequence should jump directly to wherever the previous attempt stopped (~[211/293] for the existing 293 MB cache from #27055234967).