### PR TITLE
chore(build-cache): restore 5h45m cap and remove ninja debug instrumentation

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -78,13 +78,17 @@ runs:
       run: |
         chmod +x build_linux.sh
         if [ "${USE_BUILD_CACHE}" = "1" ]; then
-          # DEBUG: temporarily capped at 60m to diagnose ninja rebuild reasons.
-          # Original cap is 5h45m (= 345m). Restore after debug.
+          # Cap the build at 5h45m. GitHub-hosted jobs are hard-cancelled at
+          # 6h, which would skip the cache save and lose the warm build dir.
+          # Stopping the build ourselves before that lets the cache be saved
+          # so a subsequent retry resumes from the warm build directory.
           rc=0
-          timeout --signal=TERM 60m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
+          timeout --signal=TERM 345m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
           if [ "${rc}" = "124" ]; then
+            # Capped: mark so the cache-save steps below run. A completed
+            # build (rc=0) leaves capped unset, so its cache is NOT saved.
             echo "capped=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Build hit the 60m debug cap."
+            echo "::warning::Build hit the 5h45m cap; build directory will be saved for a warm retry. Marking this attempt as failed."
           fi
           exit "${rc}"
         else

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -107,25 +107,6 @@ if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
     # 'output.o > input.h' mtime check now correctly says 'up to date'.
     rm -f "flash-attention/hopper/build/temp.linux-aarch64-cpython-312/.ninja_deps"
     echo "fa-build-cache: mtime fixup done (sources/headers -> $PAST, .o tree untouched, .ninja_deps dropped)"
-    # DEBUG: dump ninja state + ask ninja itself why it would rebuild.
-    # Remove this block once we confirm the fix.
-    BUILD_TEMP=flash-attention/hopper/build/temp.linux-aarch64-cpython-312
-    echo "=== DEBUG: ninja state under $BUILD_TEMP ==="
-    if [ -d "$BUILD_TEMP" ]; then
-      echo "--- representative mtimes (.o, .cpp, torch.h, cuda.h):"
-      stat -c '%y %n' "$BUILD_TEMP/flash_api_stable.o" 2>/dev/null || echo "  no .o"
-      stat -c '%y %n' flash-attention/hopper/flash_api_stable.cpp 2>/dev/null || echo "  no .cpp"
-      ls .venv/lib/python*/site-packages/torch/include/torch/torch.h 2>/dev/null \
-        | head -1 | xargs -r stat -c '%y %n' || echo "  no torch.h"
-      stat -c '%y %n' /usr/local/cuda/include/cuda.h 2>/dev/null || echo "  no cuda.h"
-      uv pip install --quiet ninja 2>/dev/null || true
-      if command -v ninja >/dev/null && [ -f "$BUILD_TEMP/build.ninja" ]; then
-        echo "--- ninja --version: $(ninja --version 2>/dev/null || true)"
-        echo "--- ninja -d explain -n (first 40 lines):"
-        (cd "$BUILD_TEMP" && ninja -d explain -n 2>&1) | head -40 || true
-      fi
-    fi
-    echo "=== END DEBUG ==="
   fi
 elif [[ "${FLASH_ATTN_VARIANT}" == "Flash Attention 2" ]]; then
   echo "Checking out flash-attention v${FLASH_ATTN_VERSION}..."


### PR DESCRIPTION
Follow-up to the build-cache debug PRs (#129, #130, #131). To be merged **only once a 60m debug build confirms the cache mechanism works** — i.e. `ninja -d explain -n` prints no rebuild reasons and the compile resumes near the previous attempt's last [N/293].

- `action.yml`: 60m → 345m timeout; restore the original warning text
- `build_linux.sh`: drop the BUILD_TEMP debug block (representative mtimes, `ninja -d explain -n` dry-run)