### PR TITLE
chore(build-cache): restore 5h45m cap for production runs

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -82,16 +82,17 @@ runs:
       run: |
         chmod +x build_linux.sh
         if [ "${USE_BUILD_CACHE}" = "1" ]; then
-          # DEBUG: temporarily capped at 10m to verify ninja skip behaviour
-          # on cache restore. Just enough time for the restore step and the
-          # first compile lines (ninja's [N/total] prefix) to appear; the
-          # full build still takes ~6h. Restore the 5h45m cap after the
-          # cache mechanism is confirmed working.
+          # Cap the build at 5h45m. GitHub-hosted jobs are hard-cancelled at
+          # 6h, which would skip the cache save and lose the warm build dir.
+          # Stopping the build ourselves before that lets the cache be saved
+          # so a subsequent retry resumes from the warm build directory.
           rc=0
-          timeout --signal=TERM 10m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
+          timeout --signal=TERM 345m ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}" || rc=$?
           if [ "${rc}" = "124" ]; then
+            # Capped: mark so the cache-save steps below run. A completed
+            # build (rc=0) leaves capped unset, so its cache is NOT saved.
             echo "capped=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Build hit the 10m verify cap."
+            echo "::warning::Build hit the 5h45m cap; build directory will be saved for a warm retry. Marking this attempt as failed."
           fi
           exit "${rc}"
         else


### PR DESCRIPTION
Test build #27086692509 verified the cache mechanism works (the cached .o tree is honored: progress shifted from [1/293] to [1/289] after restoring a 5-object cache). The 10m diagnostic cap from PR #136 (and the 60m one before it from PR #129) can now be lifted.

- Restore the original `timeout --signal=TERM 345m` (5h45m) so production runs stop ~15 min before GitHub-hosted's hard 6h cancel.
- Restore the original warning text explaining the cap purpose.

Supersedes #132 (closed; the branch had drifted too far from main to rebase cleanly).