### PR TITLE
chore(build-cache): condense verbose cache-related comments

### DIFF
--- a/.github/actions/build-and-upload/action.yml
+++ b/.github/actions/build-and-upload/action.yml
@@ -54,22 +54,15 @@ runs:
       with:
         version: ${{ inputs.cuda-version }}
 
-    # ninja build directory cache. Stores the entire
-    # flash-attention/hopper/build/ tree under ~/.fa-build-cache/ so ninja
-    # sees the .o files on the next attempt and skips already-compiled
-    # translation units. (ccache was attempted previously but FA3's nvcc
-    # invocations are 97% 'uncacheable' from ccache's perspective due to
-    # --generate-dependencies-with-compile.)
+    # ninja build directory cache so the next attempt resumes from the
+    # already-compiled .o files. See memory/project_build_cache_ninja_mtime.md
+    # for why ccache was unsuitable and how the mtime juggling works.
     - name: Restore FA3 build directory cache
       id: build_cache_restore
       if: ${{ inputs.use-build-cache == 'true' }}
       uses: actions/cache/restore@v4
       with:
         path: ~/.fa-build-cache
-        # fabuild3- prefix: cache layout changed again (mtimes are now
-        # truncated to whole seconds before save so they survive GNU tar's
-        # ustar precision loss in actions/cache@v4). Older fabuild2- caches
-        # carry nanosecond mtimes that no longer match ninja's expectations.
         key: fabuild3-linux-${{ runner.arch }}-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}-fa${{ inputs.flash-attn-version }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           fabuild3-linux-${{ runner.arch }}-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}-fa${{ inputs.flash-attn-version }}-
@@ -99,10 +92,8 @@ runs:
           ./build_linux.sh "${{ inputs.flash-attn-version }}" "${{ inputs.python-version }}" "${{ inputs.torch-version }}" "${{ inputs.cuda-version }}"
         fi
 
-    # Move the partially-built ninja directory under ~/.fa-build-cache/ so
-    # actions/cache/save can pick it up at a stable path. Also stash the
-    # cutlass/cute header tree so its mtimes survive a restore — ninja
-    # records header mtimes in .ninja_deps and matches them on the next run.
+    # Stage the build dir + cutlass tree under ~/.fa-build-cache/ so
+    # actions/cache/save picks them up at a stable path.
     - name: Stage FA3 build directory for cache save
       id: stage_build
       if: ${{ always() && inputs.use-build-cache == 'true' && steps.build.outputs.capped == 'true' }}
@@ -121,17 +112,13 @@ runs:
           echo "Staged $src -> ~/.fa-build-cache/build"
           du -sh "$HOME/.fa-build-cache/build" || true
           if [ -d flash-attention/csrc/cutlass ]; then
-            # cp -a preserves mtime; mv would be faster but git checkout
-            # would have to recreate the tree for any post-build step.
+            # cp -a (not mv) so flash-attention/ stays intact for post-build steps.
             cp -a flash-attention/csrc/cutlass "$HOME/.fa-build-cache/cutlass"
             echo "Staged cutlass -> ~/.fa-build-cache/cutlass"
             du -sh "$HOME/.fa-build-cache/cutlass" || true
           fi
-          # actions/cache@v4 archives via GNU tar (ustar), which truncates
-          # mtimes to whole seconds. ninja .ninja_deps records mtimes at
-          # nanosecond precision, so after restore the stat() values (sec.0)
-          # mismatch what was recorded (sec.NNN) and ninja rebuilds every
-          # .o. Truncate both sides now so the comparison still holds.
+          # Truncate mtimes to whole seconds so they survive GNU tar in
+          # actions/cache@v4 (ustar drops sub-second precision).
           python3 "$GITHUB_WORKSPACE/scripts/tools/truncate_build_cache_mtimes.py" \
             "$HOME/.fa-build-cache" || true
           echo "staged=true" >> "$GITHUB_OUTPUT"

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -61,39 +61,23 @@ if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
   # suppresses verbose --resource-usage ptxas logs that would otherwise
   # clutter CI output with thousands of lines per build.
   cp "$(dirname "$0")/patches/fa3/setup.py" flash-attention/hopper/setup.py
-  # If a previous attempt's ninja build directory was cached by the CI step
-  # (Restore FA3 build directory cache), move it into place so ninja sees
-  # the existing .o files and skips already-compiled translation units.
-  #
-  # ninja's .ninja_deps records each .o's input header mtimes at nanosecond
-  # precision. The cached .o tree keeps its mtimes (tar via actions/cache),
-  # but cutlass / cute headers are freshly cloned every CI run and therefore
-  # mismatch what .ninja_deps recorded — ninja would mark every dependent .o
-  # 'dirty' and rebuild from scratch. To make the recorded mtimes valid
-  # again, we also cache the cutlass/cute headers and restore them next to
-  # the build dir with their original mtimes preserved (cp/mv keep mtimes,
-  # tar in actions/cache preserves them too). The same problem exists for
-  # torch and CUDA headers, but the deps info appears to be matchable for
-  # them under our setup; if not, add them to the cache stash too.
+  # Restore the ninja build directory + cutlass headers cached by the CI
+  # action. We also push every non-cached input (FA3 sources, torch/CUDA
+  # headers) into the past so the restored .o files stay strictly newer
+  # than their inputs, then run `ninja -t restat` to sync .ninja_log with
+  # the restored mtimes. See memory/project_build_cache_ninja_mtime.md.
   if [ -d "$HOME/.fa-build-cache/build" ]; then
-    echo "fa-build-cache: restoring previous ninja build directory"
+    echo "fa-build-cache: restoring build dir"
     du -sh "$HOME/.fa-build-cache/build" || true
     mkdir -p flash-attention/hopper
     rm -rf flash-attention/hopper/build
     mv "$HOME/.fa-build-cache/build" flash-attention/hopper/build
     if [ -d "$HOME/.fa-build-cache/cutlass" ]; then
-      echo "fa-build-cache: restoring cutlass/cute headers with preserved mtimes"
+      echo "fa-build-cache: restoring cutlass"
       du -sh "$HOME/.fa-build-cache/cutlass" || true
       rm -rf flash-attention/csrc/cutlass
       mv "$HOME/.fa-build-cache/cutlass" flash-attention/csrc/cutlass
     fi
-    # The cached .o files have whole-second mtimes from the previous cap
-    # (e.g. 2026-06-07 07:34:56). The freshly cloned FA3 sources, the
-    # uv-installed torch headers and the setup-cuda CUDA headers all have
-    # mtime "now". ninja compares output.o vs each input mtime, so without
-    # this step every restored .o looks older than its .cu source and ninja
-    # rebuilds. Push every non-cached input far into the past so the .o
-    # remains strictly newer than its sources/headers.
     PAST=197001020000
     find flash-attention -path flash-attention/hopper/build -prune \
                           -o -path flash-attention/csrc/cutlass -prune \
@@ -107,28 +91,17 @@ if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
       sudo find /usr/local/cuda/include -type f \
         -exec touch -t "$PAST" {} + 2>/dev/null || true
     fi
-    echo "fa-build-cache: backdated FA3 sources + torch/CUDA headers to $PAST"
-    # Reconcile ninja's stat-based view with the restored tree:
-    # - the staging step truncated every mtime (including the per-target
-    #   mtimes inside .ninja_deps) to whole seconds before save, so the .o
-    #   stat values after tar/restore are bit-exact with what .ninja_deps
-    #   records;
-    # - run `ninja -t restat` over every .o so .ninja_log is also synced to
-    #   the restored mtimes. Without this, ninja would treat each .o as if
-    #   it had been touched out-of-band and rerun the build edge.
     BUILD_TEMP=flash-attention/hopper/build/temp.linux-aarch64-cpython-312
     if [ -f "$BUILD_TEMP/build.ninja" ]; then
       uv pip install --quiet ninja 2>/dev/null || true
       if command -v ninja >/dev/null; then
-        # Pass relative .o paths so `ninja -C $BUILD_TEMP -t restat` finds them
-        # via its build graph instead of misinterpreting absolute paths.
         ( cd "$BUILD_TEMP" \
           && find . -name '*.o' -type f -printf '%P\n' \
             | xargs -r -n 500 ninja -t restat \
         ) 2>/dev/null || true
       fi
     fi
-    echo "fa-build-cache: restore done (build + cutlass + ninja restat)"
+    echo "fa-build-cache: restore done"
   fi
 elif [[ "${FLASH_ATTN_VARIANT}" == "Flash Attention 2" ]]; then
   echo "Checking out flash-attention v${FLASH_ATTN_VERSION}..."


### PR DESCRIPTION
The build-cache restore/save logic accumulated long inline justifications across PRs #126/#134/#135/#137. Now that the mechanism is settled, replace those paragraphs with one-line summaries and point at `memory/project_build_cache_ninja_mtime.md` for the full rationale.

No behaviour change. 16 insertions / 56 deletions.