### PR TITLE
Update torch 2.12 to 2.12.1

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -28,7 +28,7 @@ LINUX_MATRIX = {
         # "2.9.1",
         "2.10.0",
         # "2.11.0",
-        # "2.12.0",
+        # "2.12.1",
     ],
     "cuda-version": [
         # "12.4",
@@ -40,7 +40,7 @@ LINUX_MATRIX = {
     ],
 }
 
-# Fill the remaining FA3 ARM64 missing wheels (torch 2.12.0 x cu12.6/13.0/13.2).
+# Fill the remaining FA3 ARM64 missing wheels (torch 2.12.1 x cu12.6/13.0/13.2).
 # FA3 is abi3, so one build python (3.12) covers all non-FT pythons. The base
 # matrix expands to 1x3 = 3 builds (no further pruning needed). Reset to the
 # broader matrix once these wheels land.
@@ -52,7 +52,7 @@ LINUX_ARM64_MATRIX = {
         "3.12",  # FA3 is abi3 (cp39-abi3); one build covers all non-FT pythons
     ],
     "torch-version": [
-        "2.12.0",
+        "2.12.1",
     ],
     "cuda-version": [
         "12.6",
@@ -62,7 +62,7 @@ LINUX_ARM64_MATRIX = {
 }
 
 # No additional excludes beyond EXCLUDE for this release: the matrix above
-# already expands to exactly the missing torch 2.12.0 x cuda triple.
+# already expands to exactly the missing torch 2.12.1 x cuda triple.
 ARM64_FA3_ALREADY_RELEASED = []
 
 LINUX_SELF_HOSTED_MATRIX = {
@@ -89,7 +89,7 @@ LINUX_SELF_HOSTED_MATRIX = {
         "2.9.1",
         "2.10.0",
         # "2.11.0",
-        # "2.12.0",
+        # "2.12.1",
     ],
     "cuda-version": [
         "12.4",
@@ -125,7 +125,7 @@ LINUX_ARM64_SELF_HOSTED_MATRIX = {
         # "2.9.1",
         # "2.10.0",
         "2.11.0",
-        "2.12.0",
+        "2.12.1",
     ],
     "cuda-version": [
         # "12.4",
@@ -161,7 +161,7 @@ LINUX_NO_CONTAINER_MATRIX = {
         # "2.9.1",
         # "2.10.0",
         "2.11.0",
-        "2.12.0",
+        "2.12.1",
     ],
     "cuda-version": [
         # "12.4",
@@ -197,7 +197,7 @@ LINUX_ARM64_NO_CONTAINER_MATRIX = {
         "2.9.1",
         "2.10.0",
         "2.11.0",
-        "2.12.0",
+        "2.12.1",
     ],
     "cuda-version": [
         # "12.4",
@@ -228,7 +228,7 @@ WINDOWS_MATRIX = {
         "2.9.1",
         "2.10.0",
         "2.11.0",
-        "2.12.0",
+        "2.12.1",
     ],
     "cuda-version": [
         "12.4",
@@ -256,7 +256,7 @@ WINDOWS_CODEBUILD_MATRIX = {
         "2.9.1",
         # "2.10.0",
         # "2.11.0",
-        # "2.12.0",
+        # "2.12.1",
     ],
     "cuda-version": [
         "12.8",
@@ -277,7 +277,7 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         "3.13",
         "3.14",
         "3.13t",
-        # "3.14t",  # Excluded: torch 2.12.0's setuptools/cpp_extension cannot
+        # "3.14t",  # Excluded: torch 2.12.x's setuptools/cpp_extension cannot
         # resolve the free-threaded import library on Windows
         # (LNK1104: python314.lib vs python314t.lib). Re-enable once PyTorch
         # / setuptools handle this for free-threaded CPython on Windows.
@@ -290,7 +290,7 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         # "2.9.1",
         # "2.10.0",
         # "2.11.0",
-        "2.12.0",
+        "2.12.1",
     ],
     "cuda-version": [
         # "12.4",

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -21,7 +21,7 @@ TORCH_FULL_VERSIONS = [
     "2.9.1",
     "2.10.0",
     "2.11.0",
-    "2.12.0",
+    "2.12.1",
 ]
 TORCH_SUPPORT_CUDA_VERSIONS = {
     "2.0": ("11.7", "11.8"),
@@ -177,7 +177,7 @@ LINUX_MATRIX = {
         "2.9.1",
         "2.10.0",
         "2.11.0",
-        "2.12.0",
+        "2.12.1",
     ],
     "cuda-version": ["12.4", "12.6", "12.8", "12.9", "13.0", "13.2"],
 }
@@ -189,12 +189,12 @@ LINUX_ARM64_MATRIX = {
         "2.9.1",
         "2.10.0",
         "2.11.0",
-        "2.12.0",
+        "2.12.1",
     ],
     "cuda-version": ["12.6", "12.8", "12.9", "13.0", "13.2"],
 }
 
-# Windows excludes "3.14t" because torch 2.12.0's setuptools/cpp_extension
+# Windows excludes "3.14t" because torch 2.12.x's setuptools/cpp_extension
 # cannot resolve the free-threaded import library on Windows
 # (LNK1104: python314.lib vs python314t.lib).
 # Note: "3.13t" continues to work because that distribution is shipped under a
@@ -208,7 +208,7 @@ WINDOWS_MATRIX = {
         "2.9.1",
         "2.10.0",
         "2.11.0",
-        "2.12.0",
+        "2.12.1",
     ],
     "cuda-version": ["12.6", "12.8", "13.0", "13.2"],
 }


### PR DESCRIPTION
A bit late, but `2.12.0` → `2.12.1`

https://dev-discuss.pytorch.org/t/pytorch-release-2-12-1/3398