### PR TITLE
feat: add resumable build cache to GitHub-hosted Windows

### DIFF
--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -33,12 +33,30 @@ on:
         required: false
         type: boolean
         default: true
+      use-build-cache:
+        description: "Whether to cache the ninja build directory across retries"
+        required: false
+        type: boolean
+        default: false
+      build-timeout-minutes:
+        description: "Minutes from job start until the build is capped so the warm cache can still be saved (only used with use-build-cache)"
+        required: false
+        type: string
+        default: "330"
 
 jobs:
   build_windows_wheels:
     name: Build wheels and Upload (Windows x86_64, GitHub hosted runner)
     runs-on: ${{ inputs.runner }}
+    # GitHub-hosted jobs are hard-cancelled at 6h; the build cap below is
+    # measured from BUILD_JOB_STARTED_AT so setup time counts toward it.
+    timeout-minutes: 360
     steps:
+      - name: Record job start time
+        shell: pwsh
+        run: |
+          "BUILD_JOB_STARTED_AT=$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())" >> $env:GITHUB_ENV
+
       - uses: actions/checkout@v6
 
       - name: Enable Git long paths
@@ -83,12 +101,78 @@ jobs:
           cuda-version: ${{ inputs.cuda-version }}
           cuda-home: ${{ env.CUDA_HOME }}
 
-      - name: Build wheels
+      # ninja build directory cache so the next attempt resumes from the
+      # already-compiled .obj files. Same key scheme as the Linux composite
+      # action: toolchain/script fingerprint + run_id, restore prefix drops
+      # only the attempt suffix so caches are shared between rerun attempts
+      # of the same workflow run only.
+      - name: Compute build cache key
+        id: cache_meta
+        if: ${{ inputs.use-build-cache }}
         shell: pwsh
         run: |
-          .\build_windows.ps1 -FlashAttnVersion "${{ inputs.flash-attn-version }}" -PythonVersion "${{ inputs.python-version }}" -TorchVersion "${{ inputs.torch-version }}" -CudaVersion "${{ inputs.cuda-version }}"
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
+          if ("${{ inputs.flash-attn-version }}" -like "fa3:*") {
+            $variant = "fa3"
+          } else {
+            $variant = "fa2"
+          }
+          $clBanner = (cmd /c "cl 2>&1 & exit 0" | Out-String)
+          $nvccBanner = (nvcc --version | Out-String)
+          $scriptContents = (Get-Content -Raw build_windows.ps1, get_torch_cuda_version.py, `
+            patches\fa3\setup_windows.py, scripts\tools\truncate_build_cache_mtimes.py, `
+            scripts\tools\validate_build_cache.py, scripts\tools\restore_build_cache.py, `
+            scripts\tools\run_with_timeout.py) -join "`n"
+          $bytes = [System.Text.Encoding]::UTF8.GetBytes($clBanner + $nvccBanner + $scriptContents)
+          $sha = [System.Security.Cryptography.SHA256]::Create().ComputeHash($bytes)
+          $fingerprint = ([System.BitConverter]::ToString($sha) -replace '-', '').Substring(0, 16).ToLower()
+          $base = "fa-build-cache-windows-${{ runner.arch }}-$variant-cu${{ inputs.cuda-version }}-torch${{ inputs.torch-version }}-py${{ inputs.python-version }}-fa${{ inputs.flash-attn-version }}-$fingerprint-${{ github.run_id }}"
+          "key=$base-${{ github.run_attempt }}" >> $env:GITHUB_OUTPUT
+          "restore-prefix=$base-" >> $env:GITHUB_OUTPUT
+          Write-Host "Cache key: $base-${{ github.run_attempt }}"
+
+      - name: Restore build directory cache
+        if: ${{ inputs.use-build-cache }}
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.fa-build-cache
+          key: ${{ steps.cache_meta.outputs.key }}
+          restore-keys: |
+            ${{ steps.cache_meta.outputs.restore-prefix }}
+
+      - name: Build wheels
+        id: build
+        shell: pwsh
+        run: |
+          if ("${{ inputs.use-build-cache }}" -eq "true") {
+            # Cap the build relative to the job start (GitHub's 6h limit
+            # covers the whole job, setup included), leaving headroom to
+            # validate, move, compress, and upload the warm build dir.
+            # run_with_timeout.py stops the whole process tree (pwsh ->
+            # python -> ninja -> cl/nvcc) and exits 124, mirroring the
+            # coreutils timeout convention used on Linux.
+            $deadline = [int]$env:BUILD_JOB_STARTED_AT + [int]"${{ inputs.build-timeout-minutes }}" * 60
+            python scripts\tools\run_with_timeout.py --deadline-epoch $deadline -- `
+              pwsh -NoProfile -File build_windows.ps1 `
+              -FlashAttnVersion "${{ inputs.flash-attn-version }}" `
+              -PythonVersion "${{ inputs.python-version }}" `
+              -TorchVersion "${{ inputs.torch-version }}" `
+              -CudaVersion "${{ inputs.cuda-version }}"
+            $rc = $LASTEXITCODE
+            if ($rc -eq 124) {
+              # Capped: mark so the cache-save steps below run. A completed
+              # build or a compile error leaves capped unset, so its cache
+              # is NOT saved.
+              "capped=true" >> $env:GITHUB_OUTPUT
+              Write-Host "::warning::Build hit the ${{ inputs.build-timeout-minutes }}m cap; build directory will be saved for a warm retry. Marking this attempt as failed."
+            }
+            if ($rc -ne 0) {
+              exit $rc
+            }
+          } else {
+            .\build_windows.ps1 -FlashAttnVersion "${{ inputs.flash-attn-version }}" -PythonVersion "${{ inputs.python-version }}" -TorchVersion "${{ inputs.torch-version }}" -CudaVersion "${{ inputs.cuda-version }}"
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
           }
           # build_windows.ps1 changes cwd (cd flash-attention[\hopper]), so use
           # absolute paths from GITHUB_WORKSPACE to locate the built wheel.
@@ -105,6 +189,55 @@ jobs:
             echo "is_fa3=false" >> $env:GITHUB_ENV
             echo "wheel_dir=$wheelDir" >> $env:GITHUB_ENV
           }
+
+      # Stage the build dir under ~/.fa-build-cache/ so actions/cache/save
+      # picks it up at a stable path. Only a validated build tree is staged;
+      # a corrupt one (e.g. .ninja_deps cut mid-write) is dropped so the
+      # rerun starts clean instead of building a broken wheel.
+      - name: Stage build directory for cache save
+        id: stage_build
+        if: ${{ always() && inputs.use-build-cache && steps.build.outputs.capped == 'true' }}
+        shell: pwsh
+        run: |
+          if ("${{ inputs.flash-attn-version }}" -like "fa3:*") {
+            $src = "flash-attention\hopper\build"
+          } else {
+            $src = "flash-attention\build"
+          }
+          "staged=false" >> $env:GITHUB_OUTPUT
+          if (-not (Test-Path $src)) {
+            Write-Host "No build directory found at $src; skipping cache save."
+            exit 0
+          }
+          python scripts\tools\validate_build_cache.py $src
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning::Build directory failed validation; skipping cache save."
+            exit 0
+          }
+          $cacheRoot = Join-Path $env:USERPROFILE ".fa-build-cache"
+          New-Item -ItemType Directory -Force -Path $cacheRoot | Out-Null
+          if (Test-Path (Join-Path $cacheRoot "build")) {
+            Remove-Item -Recurse -Force (Join-Path $cacheRoot "build")
+          }
+          Move-Item $src (Join-Path $cacheRoot "build")
+          Write-Host "Staged $src -> $cacheRoot\build"
+          # Truncate mtimes to whole seconds so they survive GNU tar in
+          # actions/cache@v4 (ustar drops sub-second precision). Exits
+          # non-zero on a corrupt .ninja_deps, in which case the save is
+          # skipped.
+          python scripts\tools\truncate_build_cache_mtimes.py $cacheRoot
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning::mtime truncation failed; skipping cache save."
+            exit 0
+          }
+          "staged=true" >> $env:GITHUB_OUTPUT
+
+      - name: Save build directory cache (only when capped)
+        if: ${{ always() && inputs.use-build-cache && steps.build.outputs.capped == 'true' && steps.stage_build.outputs.staged == 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.fa-build-cache
+          key: ${{ steps.cache_meta.outputs.key }}
 
       - name: Install Test
         shell: pwsh

--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -219,7 +219,23 @@ jobs:
           if (Test-Path (Join-Path $cacheRoot "build")) {
             Remove-Item -Recurse -Force (Join-Path $cacheRoot "build")
           }
-          Move-Item $src (Join-Path $cacheRoot "build")
+          # After a forceful process-tree kill, compilers can hold handles on
+          # the build dir for a little while; retry the move until they let go.
+          $moved = $false
+          for ($i = 1; $i -le 6; $i++) {
+            try {
+              Move-Item $src (Join-Path $cacheRoot "build") -ErrorAction Stop
+              $moved = $true
+              break
+            } catch {
+              Write-Host "Move-Item failed (attempt $i/6): $($_.Exception.Message); retrying in 10s"
+              Start-Sleep -Seconds 10
+            }
+          }
+          if (-not $moved) {
+            Write-Host "::warning::Could not move build directory; skipping cache save."
+            exit 0
+          }
           Write-Host "Staged $src -> $cacheRoot\build"
           # Truncate mtimes to whole seconds so they survive GNU tar in
           # actions/cache@v4 (ustar drops sub-second precision). Exits

--- a/.github/workflows/_build_windows.yml
+++ b/.github/workflows/_build_windows.yml
@@ -233,8 +233,16 @@ jobs:
             }
           }
           if (-not $moved) {
-            Write-Host "::warning::Could not move build directory; skipping cache save."
-            exit 0
+            # Last resort: copy file-by-file. A file still locked by a
+            # surviving compiler is skipped after robocopy's retries; such
+            # half-written objects are not recorded in .ninja_log/.ninja_deps
+            # anyway, so ninja simply rebuilds them on the warm retry.
+            Write-Host "Move-Item kept failing; falling back to robocopy"
+            robocopy $src (Join-Path $cacheRoot "build") /E /MOVE /R:3 /W:10 /NFL /NDL /NJH /NJS | Out-Null
+            if ($LASTEXITCODE -ge 8) {
+              Write-Host "::warning::Could not move build directory; skipping cache save."
+              exit 0
+            }
           }
           Write-Host "Staged $src -> $cacheRoot\build"
           # Truncate mtimes to whole seconds so they survive GNU tar in

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
       torch-version: ${{ matrix.torch-version }}
       cuda-version: ${{ matrix.cuda-version }}
+      use-build-cache: true
     secrets: inherit
 
   build_wheels_windows_code_build:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -57,7 +57,7 @@ on:
         required: false
         type: string
       use-build-cache:
-        description: "Cache the ninja build directory across retries and cap builds before the 6h job limit (GitHub-hosted Linux only)"
+        description: "Cache the ninja build directory across retries and cap builds before the 6h job limit (GitHub-hosted Linux/Windows only)"
         required: false
         type: boolean
         default: false
@@ -184,6 +184,8 @@ jobs:
       torch-version: ${{ inputs.torch-version }}
       cuda-version: ${{ inputs.cuda-version }}
       is-upload: false
+      use-build-cache: ${{ inputs.use-build-cache }}
+      build-timeout-minutes: ${{ inputs.build-timeout-minutes }}
 
   # #########################################################
   # Windows x86_64 AWS CodeBuild

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,15 @@ Pre-built Python wheel distribution for Flash Attention (v2/v3) across multiple 
 - **`test-build.yml`** — Manual `workflow_dispatch` for individual platform test builds. Forces `is-upload: false`.
 - **`_build_*.yml`** — Reusable workflows per runner type (Linux hosted/self-hosted/no-container, Windows hosted/self-hosted/CodeBuild, Linux ARM hosted/self-hosted/no-container).
 
-### GitHub-hosted Linux Resumable Build Cache (retry mechanism)
+### GitHub-hosted Resumable Build Cache (retry mechanism)
 
-`use-build-cache: true` (set in `build.yml` for `build_wheels_linux` and `build_wheels_linux_arm64`) enables, for FA2 and FA3 on both x86_64 and ARM64:
+`use-build-cache: true` (set in `build.yml` for `build_wheels_linux`, `build_wheels_linux_arm64`, and `build_wheels_windows`) enables, for FA2 and FA3:
 
 - A build cap measured from job start (`BUILD_JOB_STARTED_AT`, default `build-timeout-minutes: 330` of the job's `timeout-minutes: 360`) so setup time counts toward GitHub's hard 6h job cancel and ~30m remain to validate/compress/upload the cache.
 - `actions/cache@v4` save+restore of `~/.fa-build-cache/` (ninja build dir only; cutlass is re-initialized as a real submodule on restore because a cached copy carries a `.git` pointer into the previous runner's gitdir, breaking FA2's `check=True` submodule update in setup.py) under the `fa-build-cache-` prefix. The key includes a toolchain/script fingerprint plus `github.run_id`, so caches are only shared between rerun attempts of the same workflow run; each attempt saves its own immutable key.
 - Save only happens when the build exits with code 124 (capped by `timeout`); completed builds and compile errors never save. Before saving, `scripts/tools/validate_build_cache.py` checks the build tree (build.ninja present, objects present, every `.ninja_deps` structurally valid) and `scripts/tools/truncate_build_cache_mtimes.py` rewrites every mtime (and the int64 mtime in version-4 `.ninja_deps`) to whole seconds so they survive GNU tar's ustar precision loss. Either failing skips the save.
-- On restore, `build_linux.sh` validates the cache, moves it to the variant's build root (`flash-attention/build` for FA2, `flash-attention/hopper/build` for FA3), runs `git submodule update --init csrc/cutlass`, pushes every non-cached input (FA sources incl. cutlass, `.venv`'s torch include, `${CUDA_HOME}/include`) to `1970-01-02`, then discovers every `build.ninja` dynamically (no hardcoded `temp.linux-*` dir) and runs `ninja -t deps` + `ninja -t restat` so the restored `.o` tree stays "newer than its inputs" from ninja's perspective. Any verification failure falls back to a clean build.
+- On restore, the cache is validated, moved to the variant's build root (`flash-attention/build` for FA2, `flash-attention/hopper/build` for FA3), cutlass is re-initialized via `git submodule update --init csrc/cutlass`, every non-cached input (FA sources incl. cutlass, `.venv`'s torch include, `${CUDA_HOME}/include`) is pushed to `1970-01-02`, then every `build.ninja` is discovered dynamically (no hardcoded `temp.*` dir) and `ninja -t deps` + `ninja -t restat` run so the restored object tree stays "newer than its inputs" from ninja's perspective. Any verification failure falls back to a clean build. Linux implements this inline in `build_linux.sh`; Windows calls `scripts/tools/restore_build_cache.py` from `build_windows.ps1` (mtime rewinds over ~70k files are too slow in PowerShell).
+- Windows has no `timeout(1)`, so `_build_windows.yml` wraps `build_windows.ps1` in `scripts/tools/run_with_timeout.py`, which stops the whole process tree on expiry (CTRL_BREAK_EVENT → grace period → `taskkill /T /F`) and exits 124 like coreutils timeout.
 
 Typical run-to-completion: attempt 1 caps and saves cache → `gh run rerun <run_id> --failed` triggers attempt 2 which restores the cache, ninja skips most completed compilations, and the build finishes within the cap. See `memory/project_build_cache_ninja_mtime.md` for the full debug trail.
 
@@ -40,6 +41,8 @@ Typical run-to-completion: attempt 1 caps and saves cache → `gh run rerun <run
 - **`tools/check_missing_packages.py`** — Prints per-platform coverage tables (✓/✗/-) by hitting the GitHub Releases API.
 - **`tools/truncate_build_cache_mtimes.py`** — Stand-alone mtime truncator + strict `.ninja_deps` parser used by the cache save step.
 - **`tools/validate_build_cache.py`** — Validates a cached ninja build tree before cache save / after restore.
+- **`tools/restore_build_cache.py`** — Restores the cached build tree into a fresh clone (validate → move → cutlass init → mtime rewind → ninja restat); used by `build_windows.ps1`.
+- **`tools/run_with_timeout.py`** — Windows-aware `timeout(1)` equivalent (process-tree stop, exit 124); used by `_build_windows.yml`.
 - **`tools/fetch_all_assets.py`** — Bulk asset retrieval.
 
 ### FA3 patches (`patches/fa3/`)

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -347,6 +347,31 @@ if ($FlashAttnVariant -eq "Flash Attention 3") {
     exit 1
 }
 
+# Restore the ninja build directory saved by a capped earlier attempt, if the
+# CI workflow placed one under ~/.fa-build-cache. The heavy lifting (validate,
+# move into the variant's build root, cutlass submodule init, mtime rewind,
+# ninja -t deps / restat) happens in restore_build_cache.py; on failure it
+# cleans up and exits non-zero, and we continue with a clean build.
+$FaBuildCacheRoot = Join-Path $env:USERPROFILE ".fa-build-cache"
+if (Test-Path (Join-Path $FaBuildCacheRoot "build")) {
+    Write-Host "::group::Restoring build cache"
+    if ($FlashAttnVariant -eq "Flash Attention 3") {
+        $BuildRoot = "flash-attention\hopper\build"
+    } else {
+        $BuildRoot = "flash-attention\build"
+    }
+    python (Join-Path $PSScriptRoot "scripts\tools\restore_build_cache.py") `
+        --cache-root $FaBuildCacheRoot `
+        --repo flash-attention `
+        --build-root $BuildRoot `
+        --extra-include ".venv\Lib\site-packages\torch\include" `
+        --extra-include (Join-Path $env:CUDA_HOME "include")
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "fa-build-cache: restore failed; continuing with a clean build"
+    }
+    Write-Host "::endgroup::"
+}
+
 # Build wheels
 Write-Host "::group::Setting up build environment"
 Import-Module 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\Microsoft.VisualStudio.DevShell.dll'

--- a/doc/scripts.md
+++ b/doc/scripts.md
@@ -23,6 +23,8 @@ flash-attention-prebuild-wheels/
 │   └── tools/                                  # Manual CLI tools & CI helpers
 │       ├── check_missing_packages.py
 │       ├── fetch_all_assets.py
+│       ├── restore_build_cache.py
+│       ├── run_with_timeout.py
 │       ├── truncate_build_cache_mtimes.py
 │       └── validate_build_cache.py
 ```
@@ -269,6 +271,25 @@ Validates that a cached ninja build directory is resumable: the directory exists
 
 ```bash
 python -m scripts.tools.validate_build_cache ~/.fa-build-cache/build
+```
+
+### `restore_build_cache.py`
+
+Restores a cached ninja build tree into a fresh flash-attention clone: validate → move into the variant's build root → re-initialize the cutlass submodule → push non-cached inputs (repo sources, torch/CUDA headers) to 1970-01-02 → `ninja -t deps` / `ninja -t restat`. On failure it deletes the restored tree and exits non-zero so the caller falls back to a clean build. Called by `build_windows.ps1` (the Linux equivalent lives inline in `build_linux.sh`).
+
+```bash
+python scripts/tools/restore_build_cache.py --cache-root ~/.fa-build-cache \
+  --repo flash-attention --build-root flash-attention/hopper/build \
+  --extra-include .venv/Lib/site-packages/torch/include \
+  --extra-include "$CUDA_HOME/include"
+```
+
+### `run_with_timeout.py`
+
+Windows-aware equivalent of coreutils `timeout(1)`. Runs a command in its own process group with a Unix-epoch deadline; on expiry it stops the whole process tree (CTRL_BREAK_EVENT → grace period → `taskkill /T /F` on Windows, SIGTERM → SIGKILL elsewhere) and exits 124. Used by `_build_windows.yml` to cap builds when `use-build-cache` is enabled.
+
+```bash
+python scripts/tools/run_with_timeout.py --deadline-epoch 1750000000 -- pwsh -File build_windows.ps1 ...
 ```
 
 ---

--- a/scripts/tools/restore_build_cache.py
+++ b/scripts/tools/restore_build_cache.py
@@ -1,0 +1,187 @@
+"""Restore a resumable ninja build cache into a fresh flash-attention clone.
+
+Python counterpart of the restore block in build_linux.sh, used by
+build_windows.ps1 (updating tens of thousands of file mtimes is too slow in
+PowerShell). Steps:
+
+1. Validate the cached build tree (see validate_build_cache).
+2. Move it into the variant's build root (flash-attention/build for FA2,
+   flash-attention/hopper/build for FA3).
+3. Re-initialize the cutlass submodule (a cached copy would carry a .git
+   pointer into the previous runner's gitdir).
+4. Push every non-cached input (repo sources, torch headers, CUDA headers)
+   to 1970-01-02 so the restored .o files stay strictly newer.
+5. Discover every build.ninja under the build root, verify its metadata with
+   `ninja -t deps`, and re-stat the cached objects with `ninja -t restat`.
+
+On any failure the restored build root is deleted and the script exits
+non-zero so the caller falls back to a clean build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from validate_build_cache import validate_build_cache
+
+PAST_EPOCH = 86400  # 1970-01-02
+
+
+def touch_tree_to_past(root: Path, skip: list[Path]) -> int:
+    """Set the mtime of every file under ``root`` to 1970-01-02.
+
+    Args:
+        root: Directory tree to walk.
+        skip: Directories to leave untouched (the restored build root).
+
+    Returns:
+        The number of files updated.
+    """
+    skip_resolved = {p.resolve() for p in skip}
+    count = 0
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames if (Path(dirpath) / d).resolve() not in skip_resolved
+        ]
+        for name in filenames:
+            try:
+                os.utime(Path(dirpath) / name, times=(PAST_EPOCH, PAST_EPOCH))
+                count += 1
+            except OSError:
+                continue
+    return count
+
+
+def restat_ninja_dirs(build_root: Path) -> bool:
+    """Verify and re-stat every ninja build directory under ``build_root``.
+
+    Args:
+        build_root: The restored build root.
+
+    Returns:
+        True if every discovered ninja dir passed `ninja -t deps` and
+        `ninja -t restat`; False otherwise.
+    """
+    ninja_files = sorted(build_root.rglob("build.ninja"))
+    if not ninja_files:
+        print("restore-build-cache: no build.ninja found", file=sys.stderr)
+        return False
+    for ninja_file in ninja_files:
+        ninja_dir = ninja_file.parent
+        print(f"restore-build-cache: verifying {ninja_dir}")
+        deps = subprocess.run(
+            ["ninja", "-t", "deps"], cwd=ninja_dir, capture_output=True, check=False
+        )
+        if deps.returncode != 0:
+            print(
+                f"restore-build-cache: ninja -t deps failed in {ninja_dir}",
+                file=sys.stderr,
+            )
+            return False
+        objects = [
+            str(p.relative_to(ninja_dir))
+            for p in ninja_dir.rglob("*")
+            if p.suffix in (".o", ".obj") and p.is_file()
+        ]
+        for start in range(0, len(objects), 500):
+            restat = subprocess.run(
+                ["ninja", "-t", "restat", *objects[start : start + 500]],
+                cwd=ninja_dir,
+                check=False,
+            )
+            if restat.returncode != 0:
+                print(
+                    f"restore-build-cache: ninja -t restat failed in {ninja_dir}",
+                    file=sys.stderr,
+                )
+                return False
+    return True
+
+
+def main() -> int:
+    """Restore the cached build tree; entry point for CLI use."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cache-root",
+        type=Path,
+        required=True,
+        help="Cache root holding the saved build dir, e.g. ~/.fa-build-cache",
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        required=True,
+        help="Path to the flash-attention clone",
+    )
+    parser.add_argument(
+        "--build-root",
+        type=Path,
+        required=True,
+        help="Destination build root, e.g. flash-attention/hopper/build",
+    )
+    parser.add_argument(
+        "--extra-include",
+        type=Path,
+        action="append",
+        default=[],
+        help="Additional header tree to push into the past (torch include, CUDA include); repeatable",
+    )
+    args = parser.parse_args()
+    cache_root: Path = args.cache_root.expanduser()
+    cached_build = cache_root / "build"
+    build_root: Path = args.build_root
+
+    if not cached_build.is_dir():
+        print(f"restore-build-cache: no cached build at {cached_build}; nothing to do")
+        return 0
+
+    print(f"restore-build-cache: restoring {cached_build} into {build_root}")
+    problems = validate_build_cache(cached_build)
+    if problems:
+        for problem in problems:
+            print(f"restore-build-cache: {problem}", file=sys.stderr)
+        print("restore-build-cache: cached build failed validation; using clean build")
+        shutil.rmtree(cache_root, ignore_errors=True)
+        return 1
+
+    build_root.parent.mkdir(parents=True, exist_ok=True)
+    if build_root.exists():
+        shutil.rmtree(build_root)
+    shutil.move(str(cached_build), str(build_root))
+
+    # Normally done inside setup.py; doing it before the past-touch keeps the
+    # cutlass headers older than the cached objects.
+    print("restore-build-cache: initializing cutlass submodule")
+    submodule = subprocess.run(
+        ["git", "-C", str(args.repo), "submodule", "update", "--init", "csrc/cutlass"],
+        check=False,
+    )
+    if submodule.returncode != 0:
+        print("restore-build-cache: cutlass submodule init failed", file=sys.stderr)
+        shutil.rmtree(build_root, ignore_errors=True)
+        return 1
+
+    touched = touch_tree_to_past(args.repo, skip=[build_root])
+    for include_root in args.extra_include:
+        if include_root.is_dir():
+            touched += touch_tree_to_past(include_root, skip=[])
+    print(f"restore-build-cache: pushed {touched} input files to 1970-01-02")
+
+    if not restat_ninja_dirs(build_root):
+        print("restore-build-cache: verification failed; using clean build")
+        shutil.rmtree(build_root, ignore_errors=True)
+        return 1
+
+    print("restore-build-cache: restore done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/run_with_timeout.py
+++ b/scripts/tools/run_with_timeout.py
@@ -1,0 +1,125 @@
+"""Run a command with a deadline, like coreutils timeout(1), but Windows-aware.
+
+GitHub-hosted Windows runners have no `timeout --signal=TERM`, and stopping a
+build there means stopping a whole process tree (pwsh -> python -> ninja ->
+cl/nvcc); killing only the direct child leaves compilers running. On expiry
+this script:
+
+1. Sends CTRL_BREAK_EVENT to the child's process group (Windows) or SIGTERM
+   (POSIX) so ninja can finish writing its logs.
+2. Waits a grace period.
+3. Falls back to `taskkill /T /F` (Windows) or SIGKILL (POSIX).
+
+Exits with 124 on timeout (same convention as timeout(1)) so the caller's
+capped-build detection works identically on Linux and Windows.
+
+Usage:
+    python run_with_timeout.py --deadline-epoch 1750000000 -- cmd arg1 arg2
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+
+TIMEOUT_EXIT_CODE = 124
+
+
+def stop_process_tree(proc: subprocess.Popen, grace_seconds: int) -> None:
+    """Stop ``proc`` and its descendants, gently first, then forcefully.
+
+    Args:
+        proc: The child process (created in its own process group / session).
+        grace_seconds: Seconds to wait after the gentle signal before the
+            forceful kill.
+    """
+    if sys.platform == "win32":
+        # Reaches every process in the child's console process group.
+        proc.send_signal(signal.CTRL_BREAK_EVENT)
+    else:
+        os.killpg(proc.pid, signal.SIGTERM)
+    try:
+        proc.wait(timeout=grace_seconds)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    print(
+        f"run-with-timeout: process tree still alive after {grace_seconds}s grace; killing",
+        file=sys.stderr,
+    )
+    if sys.platform == "win32":
+        subprocess.run(
+            ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+            capture_output=True,
+            check=False,
+        )
+    else:
+        os.killpg(proc.pid, signal.SIGKILL)
+    proc.wait()
+
+
+def main() -> int:
+    """Run the wrapped command under a deadline; entry point for CLI use."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--deadline-epoch",
+        type=int,
+        required=True,
+        help="Unix epoch seconds at which the command is stopped",
+    )
+    parser.add_argument(
+        "--grace-seconds",
+        type=int,
+        default=30,
+        help="Wait this long after the gentle stop before the forceful kill",
+    )
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="Command to run (prefix with -- to separate from options)",
+    )
+    args = parser.parse_args()
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("no command given")
+
+    remaining = args.deadline_epoch - int(time.time())
+    if remaining <= 0:
+        print(
+            f"run-with-timeout: deadline already passed ({-remaining}s ago); not starting",
+            file=sys.stderr,
+        )
+        return TIMEOUT_EXIT_CODE
+
+    print(f"run-with-timeout: deadline in {remaining}s")
+    creationflags = (
+        subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0
+    )
+    start_new_session = sys.platform != "win32"
+    proc = subprocess.Popen(
+        command,
+        creationflags=creationflags,
+        start_new_session=start_new_session,
+    )
+    try:
+        return proc.wait(timeout=remaining)
+    except subprocess.TimeoutExpired:
+        print(
+            f"run-with-timeout: deadline reached after {remaining}s; stopping process tree",
+            file=sys.stderr,
+        )
+        stop_process_tree(proc, args.grace_seconds)
+        return TIMEOUT_EXIT_CODE
+    except KeyboardInterrupt:
+        stop_process_tree(proc, args.grace_seconds)
+        raise
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/run_with_timeout.py
+++ b/scripts/tools/run_with_timeout.py
@@ -28,6 +28,22 @@ import time
 
 TIMEOUT_EXIT_CODE = 124
 
+# taskkill /T walks a snapshot of the process tree, so compilers whose parent
+# (ninja) already exited on CTRL_BREAK become orphans and survive it. They
+# keep running (and keep handles on the build dir) for the rest of their
+# compile, so sweep the known build executables by name afterwards.
+WINDOWS_BUILD_PROCESS_NAMES = (
+    "ninja.exe",
+    "nvcc.exe",
+    "cicc.exe",
+    "cudafe++.exe",
+    "ptxas.exe",
+    "fatbinary.exe",
+    "nvlink.exe",
+    "cl.exe",
+    "link.exe",
+)
+
 
 def stop_process_tree(proc: subprocess.Popen, grace_seconds: int) -> None:
     """Stop ``proc`` and its descendants, gently first, then forcefully.
@@ -57,6 +73,12 @@ def stop_process_tree(proc: subprocess.Popen, grace_seconds: int) -> None:
             capture_output=True,
             check=False,
         )
+        for name in WINDOWS_BUILD_PROCESS_NAMES:
+            subprocess.run(
+                ["taskkill", "/IM", name, "/F", "/T"],
+                capture_output=True,
+                check=False,
+            )
     else:
         os.killpg(proc.pid, signal.SIGKILL)
     proc.wait()

--- a/scripts/tools/run_with_timeout.py
+++ b/scripts/tools/run_with_timeout.py
@@ -60,6 +60,10 @@ def stop_process_tree(proc: subprocess.Popen, grace_seconds: int) -> None:
     else:
         os.killpg(proc.pid, signal.SIGKILL)
     proc.wait()
+    # taskkill returns before the descendants have fully exited and released
+    # their file handles; without this pause the caller's Move-Item on the
+    # build directory can fail with a sharing violation.
+    time.sleep(10)
 
 
 def main() -> int:


### PR DESCRIPTION
## Overview and Background

PR #144 introduced a resumable ninja build cache for GitHub-hosted Linux runners: cap the build before the 6-hour job limit, save the ninja build directory via `actions/cache`, and resume from the warm cache on `gh run rerun --failed`. This PR extends the same mechanism to **GitHub-hosted Windows runners (FA2 + FA3)**.

Windows needed two pieces Linux got for free:

- **No `timeout(1)`**: stopping a Windows build means stopping a whole process tree (`pwsh` → `python` → `ninja` → `cl`/`nvcc`); killing only the direct child leaves compilers running. A new `run_with_timeout.py` provides a Windows-aware equivalent (CTRL_BREAK_EVENT → grace period → `taskkill /T /F`) that exits 124 like coreutils timeout.
- **Slow mtime rewinds in PowerShell**: the restore step rewinds ~70k input file mtimes to 1970-01-02; doing that in PowerShell takes minutes, so the whole restore flow lives in a new Python script shared-ready for other platforms.

Self-hosted Windows and AWS CodeBuild remain out of scope.

## Related Issues

None. Follow-up to #144.

## Changes

### `scripts/tools/run_with_timeout.py` (new)

- Runs the wrapped command in its own process group (`CREATE_NEW_PROCESS_GROUP` on Windows, `start_new_session` on POSIX) with a Unix-epoch deadline
- On expiry: CTRL_BREAK_EVENT to the group → grace period (default 30 s) → `taskkill /PID <pid> /T /F` (POSIX: SIGTERM → SIGKILL via `killpg`), then exits **124** so the capped-build detection works identically on Linux and Windows
- The gentle-first sequence gives ninja a chance to finish writing `.ninja_deps`; if the log is still cut mid-write, the strict parser from #144 rejects it and the save is skipped

### `scripts/tools/restore_build_cache.py` (new)

Python counterpart of the restore block in `build_linux.sh`, called from `build_windows.ps1`:

1. Validate the cached tree (`validate_build_cache`)
2. Move it into the variant's build root (`flash-attention\build` for FA2, `flash-attention\hopper\build` for FA3)
3. Re-initialize the cutlass submodule (a cached copy would carry a stale `.git` pointer — the same failure #144 fixed on Linux)
4. Rewind repo sources, torch headers, and CUDA headers to 1970-01-02
5. Discover every `build.ninja` dynamically, verify with `ninja -t deps`, re-stat objects with `ninja -t restat`

Any failure deletes the restored tree and exits non-zero; the build continues clean.

### `.github/workflows/_build_windows.yml`

- New `use-build-cache` / `build-timeout-minutes` (default `330`) inputs; job `timeout-minutes: 360`
- First step records `BUILD_JOB_STARTED_AT` so the cap is measured from job start (setup time counts toward GitHub's 6h whole-job limit)
- `Compute build cache key`: `fa-build-cache-windows-{arch}-{fa2|fa3}-cu{cuda}-torch{torch}-py{python}-fa{version}-{fingerprint}-{run_id}-{attempt}`; the fingerprint hashes the `cl`/`nvcc` banners plus `build_windows.ps1`, `get_torch_cuda_version.py`, `patches/fa3/setup_windows.py`, and the cache tool scripts. The restore prefix drops only the attempt suffix, so caches are shared **only between rerun attempts of the same workflow run**
- Build step wraps `build_windows.ps1` in `run_with_timeout.py` when the cache is enabled and emits `capped=true` on exit 124
- Stage step (only when capped): validate → move to `~/.fa-build-cache/build` → `truncate_build_cache_mtimes.py` (skips the save on any failure), then `actions/cache/save` under the per-attempt key

### `build_windows.ps1`

- After checkout (and the CUDA 13 alignment patches for FA3), invokes `restore_build_cache.py` when `~/.fa-build-cache/build` exists; falls back to a clean build if it exits non-zero

### Workflows

- `build.yml`: `use-build-cache: true` for `build_wheels_windows`
- `test-build.yml`: passes `use-build-cache` / `build-timeout-minutes` to `windows-github-hosted`

## Test Instructions

Forced-timeout hosted verification (all passed — see the detailed comment below with per-run links):

- **FA2** ([run 30064719964](https://github.com/mjun0812/flash-attention-prebuild-wheels/actions/runs/30064719964)): attempt 1 stopped within the CTRL_BREAK grace, saved key `…-1`; attempt 2 restored into `flash-attention\build`, rewound 18,535 input mtimes, and compiled 9 objects **disjoint** from attempt 1's 10 (zero recompiles), then re-capped and saved key `…-2`
- **FA3** ([run 30086547178](https://github.com/mjun0812/flash-attention-prebuild-wheels/actions/runs/30086547178)): attempt 1 went through the forceful kill + orphan-compiler sweep path and still produced a valid cache; attempt 2 restored into `flash-attention\hopper\build` and compiled 28 objects **disjoint** from attempt 1's 23, then re-capped and saved key `…-2`

Local verification (all passing):

```bash
# run_with_timeout: exit-code propagation, tree kill on timeout, expired deadline
python3 scripts/tools/run_with_timeout.py --deadline-epoch $(($(date +%s) + 60)) -- sh -c "exit 7"   # -> 7
python3 scripts/tools/run_with_timeout.py --deadline-epoch $(($(date +%s) + 2)) --grace-seconds 2 \
  -- sh -c "sleep 60 & sleep 120"                                                                    # -> 124, no leaked processes
python3 scripts/tools/run_with_timeout.py --deadline-epoch $(($(date +%s) - 5)) -- echo hi           # -> 124

# restore_build_cache: full flow against a real git submodule and a real
# ninja-generated .ninja_deps (success, corrupt-cache fallback, no-op)

# Lint / syntax
uvx ruff format --check scripts/tools/run_with_timeout.py scripts/tools/restore_build_cache.py
uvx ruff check scripts/tools/run_with_timeout.py scripts/tools/restore_build_cache.py
# Workflow YAML validated with PyYAML
```
