### PR TITLE
build: fill missing Windows flash-attn 2.8.3 and FA3 x torch 2.13.0 wheels

### DIFF
--- a/create_matrix.py
+++ b/create_matrix.py
@@ -214,6 +214,7 @@ LINUX_ARM64_NO_CONTAINER_MATRIX = {
 WINDOWS_MATRIX = {
     "flash-attn-version": [
         "2.8.3",
+        FA3_COMMIT,
     ],
     "python-version": [
         "3.10",
@@ -223,25 +224,32 @@ WINDOWS_MATRIX = {
         "3.14",
     ],
     "torch-version": [
-        "2.5.1",
-        "2.6.0",
-        "2.7.1",
-        "2.8.0",
-        "2.9.1",
-        "2.10.0",
-        "2.11.0",
-        "2.12.1",
+        # "2.5.1",
+        # "2.6.0",
+        # "2.7.1",
+        # "2.8.0",
+        # "2.9.1",
+        # "2.10.0",
+        # "2.11.0",
+        # "2.12.1",
         "2.13.0",
     ],
     "cuda-version": [
-        "12.4",
+        # "12.4",
         "12.6",
-        "12.8",
-        "12.9",
+        # "12.8",
+        # "12.9",
         "13.0",
         "13.2",
     ],
 }
+
+# FA3 wheels are abi3 (cp39-abi3), so one build covers all non-FT pythons.
+# Build FA3 only with Python 3.12 and let the abi3 wheel fill the rest.
+WINDOWS_FA3_SINGLE_PYTHON_EXCLUDE = [
+    {"flash-attn-version": FA3_COMMIT, "python-version": python_version}
+    for python_version in ["3.10", "3.11", "3.13", "3.14"]
+]
 
 WINDOWS_CODEBUILD_MATRIX = {
     "flash-attn-version": [
@@ -315,8 +323,8 @@ def main():
                 "linux": False,
                 # "linux": LINUX_MATRIX,
                 #
-                # "linux_arm64": False,
-                "linux_arm64": LINUX_ARM64_MATRIX,
+                "linux_arm64": False,
+                # "linux_arm64": LINUX_ARM64_MATRIX,
                 #
                 "linux_self_hosted": False,
                 # "linux_self_hosted": LINUX_SELF_HOSTED_MATRIX,
@@ -330,8 +338,8 @@ def main():
                 "linux_arm64_no_container": False,
                 # "linux_arm64_no_container": LINUX_ARM64_NO_CONTAINER_MATRIX,
                 #
-                "windows": False,
-                # "windows": WINDOWS_MATRIX,
+                # "windows": False,
+                "windows": WINDOWS_MATRIX,
                 #
                 "windows_self_hosted": False,
                 # "windows_self_hosted": WINDOWS_SELF_HOSTED_MATRIX,
@@ -339,7 +347,7 @@ def main():
                 "windows_code_build": False,
                 # "windows_code_build": WINDOWS_CODEBUILD_MATRIX,
                 #
-                "exclude": EXCLUDE,
+                "exclude": EXCLUDE + WINDOWS_FA3_SINGLE_PYTHON_EXCLUDE,
             }
         )
     )


### PR DESCRIPTION
## Overview and Background

The Windows wheel coverage currently has 30 missing cells, all for torch 2.13.0: flash-attn 2.8.3 and FA3 (`fa3:e2743ab`) x CUDA 12.6 / 13.0 / 13.2 x Python 3.10-3.14 (81.1% coverage per `check_missing_packages`). Now that the resumable build cache for GitHub-hosted Windows runners is merged (#145), these can be built on GitHub-hosted runners. This PR scopes `create_matrix.py` to exactly those missing wheels so the next `v*` tag push fills them.

## Changes

- `WINDOWS_MATRIX`: scope torch to `2.13.0` and CUDA to `12.6` / `13.0` / `13.2`, and add the FA3 commit alongside `2.8.3`
- Add `WINDOWS_FA3_SINGLE_PYTHON_EXCLUDE`: FA3 wheels are abi3 (`cp39-abi3`), so exclude FA3 x Python 3.10/3.11/3.13/3.14 and build it once with Python 3.12 per CUDA version; the single wheel covers all 15 missing FA3 cells
- `main()`: enable `windows` (GitHub-hosted, `use-build-cache: true` in `build.yml`) and disable `linux_arm64`, whose backfill completed in v0.9.49

Resulting matrix: 18 jobs (15 FA2 + 3 FA3).

## Test Instructions

Matrix generation verified locally:

```bash
uv run --python 3.14 --script create_matrix.py | python3 -m json.tool
```

Simulating GitHub's matrix `exclude` filtering over the generated JSON yields exactly the expected 18 jobs, matching the 30 missing cells reported by:

```bash
uv run --with requests --with rich --with pandas -m scripts.tools.check_missing_packages --platform windows --list-missing
```

The actual builds run when a `v*` tag is pushed. Windows GitHub-hosted FA2/FA3 builds may hit the 330-min cap on cold attempts; retry with `gh run rerun <run_id> --failed` to resume from the saved build cache (#144 / #145 flow).
