### PR TITLE
fix: resolve MSVC C2666 error in sizes() comparisons with torch 2.13

### DIFF
--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -264,6 +264,34 @@ function Apply-CudaToolkitPatch {
     Write-Host "$Description applied successfully"
 }
 
+function Patch-SizesComparisons {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$SourcePath
+    )
+
+    # torch 2.13.0 reworked c10::ArrayRef on top of HeaderOnlyArrayRef with
+    # hidden-friend operator== overloads (pytorch/pytorch#170470, #185379),
+    # which MSVC rejects as ambiguous (error C2666) wherever flash-attn
+    # compares x.sizes() with a torch::IntArrayRef (the CHECK_SHAPE macro and
+    # the alibi_slopes checks). Call .equals() explicitly instead; it exists
+    # on all supported torch versions, so patch unconditionally.
+    $pattern = '(\w+)\.sizes\(\) == (torch::IntArrayRef\(\{[^}]*\}\))'
+    $content = Get-Content -Raw $SourcePath
+    $count = [regex]::Matches($content, $pattern).Count
+    if ($count -eq 0) {
+        Write-Error "No sizes() == torch::IntArrayRef comparison found in ${SourcePath}; upstream code may have changed"
+        exit 1
+    }
+    $content = [regex]::Replace($content, $pattern, '$1.sizes().equals($2)')
+    if ($content -match '\.sizes\(\) ==') {
+        Write-Error "Unpatched sizes() == comparison remains in ${SourcePath}; the pattern needs updating"
+        exit 1
+    }
+    Set-Content -Path $SourcePath -Value $content -NoNewline
+    Write-Host "Patched $count sizes() comparison(s) to .equals() in $SourcePath"
+}
+
 Write-Host "Building Flash Attention with parameters:"
 Write-Host "  Flash-Attention: $FlashAttnVersion"
 Write-Host "  Python: $PythonVersion"
@@ -317,6 +345,7 @@ if ($FlashAttnVariant -eq "Flash Attention 3") {
     # Replace upstream setup.py with patched version
     $patchedSetup = Join-Path $PSScriptRoot "patches\fa3\setup_windows.py"
     Copy-Item $patchedSetup "flash-attention\hopper\setup.py" -Force
+    Patch-SizesComparisons -SourcePath "flash-attention\hopper\flash_api.cpp"
     # MSVC cannot pass 128-byte aligned CUDA-generated types by value on CUDA 13.0+.
     if (Test-Cuda13OrNewer -Version $CudaVersion) {
         $cutlassPatch = Join-Path $PSScriptRoot "patches\fa3\cutlass_alignment_fix.patch"
@@ -336,6 +365,7 @@ if ($FlashAttnVariant -eq "Flash Attention 3") {
 } elseif ($FlashAttnVariant -eq "Flash Attention 2") {
     Write-Host "::group::Checking out flash-attention v$FlashAttnVersion"
     git clone -q https://github.com/Dao-AILab/flash-attention.git flash-attention -b "v$FlashAttnVersion"
+    Patch-SizesComparisons -SourcePath "flash-attention\csrc\flash_attn\flash_api.cpp"
     # Remove FA4 (flash_attn/cute) to prevent it from being included in the FA2 wheel
     if (Test-Path "flash-attention\flash_attn\cute") {
         Remove-Item -Recurse -Force "flash-attention\flash_attn\cute"


### PR DESCRIPTION
## Overview and Background

All 18 Windows GitHub-hosted jobs of release v0.9.50 (run 30161010454) failed to compile flash-attn with torch 2.13.0: MSVC rejects every `x.sizes() == torch::IntArrayRef({...})` comparison in `flash_api.cpp` with `error C2666: 'c10::HeaderOnlyArrayRef<int64_t>::operator ==': overloaded functions have similar conversions`.

Root cause: torch 2.13.0 (released 2026-07-08) reworked `c10::ArrayRef` on top of `HeaderOnlyArrayRef` with hidden-friend `operator==` overloads (pytorch/pytorch#170470, pytorch/pytorch#185379). MSVC then sees four viable `==` candidates (`HeaderOnlyArrayRef`, `OptionalArrayRef`, `IValue`, `SymbolicShape`) and reports an ambiguity; gcc/clang resolve it fine, which is why Linux/ARM64 builds of the same combinations pass. Neither pytorch (main branch, no v2.13.1 yet) nor upstream flash-attention has a fix or even a report of this as of 2026-07-26; upstream reports will be filed separately.

## Changes

- Add `Patch-SizesComparisons` to `build_windows.ps1`: after checking out flash-attention, rewrite every `<ident>.sizes() == torch::IntArrayRef({...})` in `flash_api.cpp` to `<ident>.sizes().equals(torch::IntArrayRef({...}))`.
  - Applied to FA2 (`csrc/flash_attn/flash_api.cpp`: the `CHECK_SHAPE` macro plus the two `alibi_slopes` checks) and FA3 (`hopper/flash_api.cpp`: the `CHECK_SHAPE` macro).
  - Applied unconditionally: `ArrayRef::equals()` has existed for all supported torch versions and is semantically identical, so no torch-version gate is needed. Linux builds are untouched (Windows-only script).
  - Fails the build loudly if the pattern is not found, or if any `sizes() ==` comparison survives the rewrite (guards against future upstream changes).
- `build_windows.ps1` is part of the build-cache key fingerprint, so stale pre-patch caches can never be restored onto patched builds.

## Test Instructions

CUDA compilation cannot run locally (macOS); the function itself was validated with PowerShell 7 against the real pinned sources:

```powershell
# Parse check: 0 errors. Then extract Patch-SizesComparisons and run it on
# flash_api.cpp from FA2 v2.6.3 / v2.7.4 / v2.8.3 and FA3 e2743ab:
#   -> "Patched 3 sizes() comparison(s)" for each FA2 version, 1 for FA3
#   -> zero `sizes() ==` occurrences remain in any file
#   -> re-running on a patched file exits 1 ("No sizes() == ... found")
```

The resulting FA2 v2.8.3 line 341 becomes:

```cpp
TORCH_CHECK(alibi_slopes.sizes().equals(torch::IntArrayRef({num_heads})) || alibi_slopes.sizes().equals(torch::IntArrayRef({batch_size, num_heads})));
```

End-to-end verification requires a Windows CI build: after merging, re-tag (v0.9.51) to rerun the 18-job matrix from #147, or dispatch `test-build.yml` → `windows-github-hosted` with one torch 2.13.0 combination first.
