### PR TITLE
fix: extend MSVC C2666 sizes() patch to torch C++ frontend headers

### DIFF
--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -267,24 +267,31 @@ function Apply-CudaToolkitPatch {
 function Patch-SizesComparisons {
     param(
         [Parameter(Mandatory=$true)]
-        [string]$SourcePath
+        [string]$SourcePath,
+
+        [switch]$AllowNoMatch
     )
 
     # torch 2.13.0 reworked c10::ArrayRef on top of HeaderOnlyArrayRef with
     # hidden-friend operator== overloads (pytorch/pytorch#170470, #185379),
-    # which MSVC rejects as ambiguous (error C2666) wherever flash-attn
-    # compares x.sizes() with a torch::IntArrayRef (the CHECK_SHAPE macro and
-    # the alibi_slopes checks). Call .equals() explicitly instead; it exists
-    # on all supported torch versions, so patch unconditionally.
-    $pattern = '(\w+)\.sizes\(\) == (torch::IntArrayRef\(\{[^}]*\}\))'
+    # which MSVC rejects as ambiguous (error C2666) wherever a sizes() result
+    # is compared with == (flash-attn's CHECK_SHAPE macro and alibi_slopes
+    # checks, and torch's own C++ frontend headers). Call .equals() explicitly
+    # instead; it exists on all supported torch versions, so patch
+    # unconditionally. Handles `a.sizes() == b.sizes()` (incl. `b[i].sizes()`
+    # and a line break around ==) and `a.sizes() == [torch::]IntArrayRef({...})`.
+    $pattern = '(\w+(?:\[\w+\])?)\.sizes\(\)\s*==\s*((?:torch::)?IntArrayRef\(\{[^}]*\}\)|\w+(?:\[\w+\])?\.sizes\(\))'
     $content = Get-Content -Raw $SourcePath
     $count = [regex]::Matches($content, $pattern).Count
     if ($count -eq 0) {
-        Write-Error "No sizes() == torch::IntArrayRef comparison found in ${SourcePath}; upstream code may have changed"
+        if ($AllowNoMatch) {
+            return
+        }
+        Write-Error "No patchable sizes() comparison found in ${SourcePath}; upstream code may have changed"
         exit 1
     }
     $content = [regex]::Replace($content, $pattern, '$1.sizes().equals($2)')
-    if ($content -match '\.sizes\(\) ==') {
+    if ($content -match '\.sizes\(\)\s*==') {
         Write-Error "Unpatched sizes() == comparison remains in ${SourcePath}; the pattern needs updating"
         exit 1
     }
@@ -325,6 +332,17 @@ python -V
 python -c "import torch; print('PyTorch:', torch.__version__)"
 python -c "import torch; print('CUDA:', torch.version.cuda)"
 python -c "from torch.utils import cpp_extension; print(cpp_extension.CUDA_HOME)"
+Write-Host "::endgroup::"
+
+# torch 2.13.0's own C++ frontend headers contain the same MSVC-ambiguous
+# sizes() comparisons (nn/functional/{activation,embedding,loss}.h etc.),
+# which break every extension TU that includes them. Patch the installed
+# headers in the venv the same way as the flash-attn sources below.
+Write-Host "::group::Patching torch headers for MSVC sizes() == ambiguity"
+$TorchApiInclude = Join-Path $PSScriptRoot ".venv\Lib\site-packages\torch\include\torch\csrc\api\include"
+Get-ChildItem -Path $TorchApiInclude -Recurse -Filter *.h | ForEach-Object {
+    Patch-SizesComparisons -SourcePath $_.FullName -AllowNoMatch
+}
 Write-Host "::endgroup::"
 
 # FlashAttention Variant handling


### PR DESCRIPTION
## Overview and Background

Follow-up to #148. The v0.9.51 run (30185766070) proved the flash-attn-side patch works (`Patched 3 sizes() comparison(s)` appears in the logs and all `flash_api.cpp` C2666 errors are gone), but the FA2 jobs still failed: the same `error C2666: 'c10::HeaderOnlyArrayRef<int64_t>::operator =='` is also emitted from **torch 2.13.0's own C++ frontend headers**, which `flash_api.cpp` includes transitively:

- `torch/csrc/api/include/torch/nn/functional/embedding.h:103`
- `torch/csrc/api/include/torch/nn/functional/activation.h:674, 884, 910`
- `torch/csrc/api/include/torch/nn/functional/loss.h:106, 996`

These 6 sites were already present in the v0.9.50 failure logs but were missed in the initial analysis (only the `flash_api.cpp` occurrences were examined). This means every C++ extension TU that includes these headers fails to build with MSVC + torch 2.13.0, independent of flash-attn; upstream reports to pytorch will be filed separately.

## Changes

- Generalize `Patch-SizesComparisons` in `build_windows.ps1`:
  - now also rewrites `a.sizes() == b.sizes()` (including indexed operands like `inputs[0].sizes()` and a line break around `==`) in addition to `a.sizes() == [torch::]IntArrayRef({...})`
  - new `-AllowNoMatch` switch for sweeping files that may legitimately contain no comparison
- After `pip install torch`, sweep every `*.h` under `.venv\...\torch\csrc\api\include` and patch matches. A static enumeration of torch v2.13.0 shows 8 sites in 5 files (the 6 above plus `detail/TensorDataContainer.h:134` and `nn/parallel/data_parallel.h:75`).
- The flash-attn source patching from #148 is unchanged (still fail-fast); the venv sweep is tolerant so a future fixed torch version builds without changes.

## Test Instructions

Validated with PowerShell 7 against the real files (script parse: 0 errors):

- torch v2.13.0 headers: `TensorDataContainer.h` 1, `activation.h` 3, `embedding.h` 1, `loss.h` 2, `data_parallel.h` 1 replacement(s); zero `sizes() ==` remain
- flash-attn v2.6.3 / v2.7.4 / v2.8.3 (3 each) and FA3 `e2743ab` (1) still patch correctly
- Tricky cases verified by eye: the multi-line `attn_output_weights.sizes() ==\n IntArrayRef({...})` collapses into a single `.equals(...)` call; `!(target.sizes() == input.sizes())` keeps its negation; `inputs[0].sizes()` is preserved

End-to-end verification still requires a Windows CI build (re-tag after merge, or dispatch `test-build.yml` → `windows-github-hosted` with one torch 2.13.0 combination first).
