### PR TITLE
fix: build Windows wheels for torch >= 2.13 with MSVC /permissive- and C++20

### DIFF
--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -264,6 +264,30 @@ function Apply-CudaToolkitPatch {
     Write-Host "$Description applied successfully"
 }
 
+function Patch-Fa2SetupMsvcConformance {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$SetupPath
+    )
+
+    # torch 2.13.0 headers fail under MSVC's legacy mode (error C2666 on
+    # ArrayRef operator==, pytorch/pytorch#185379) and, once conformance mode
+    # is on, additionally require C++20 (C7555/C7582), so switch the
+    # host-only cxx flags to /permissive- + /std:c++20. The "nvcc" flag list
+    # must stay untouched: feeding these flags into nvcc-spawned cl.exe
+    # crashes cudafe++ (0xC0000409). patches/fa3/setup_windows.py carries the
+    # same flags for FA3 directly.
+    $old = '["-O2", "/std:c++17", "/Zc:__cplusplus"]'
+    $new = '["-O2", "/permissive-", "/std:c++20", "/Zc:__cplusplus"]'
+    $content = Get-Content -Raw $SetupPath
+    if (-not $content.Contains($old)) {
+        Write-Error "Windows cxx flag list not found in ${SetupPath}; upstream setup.py may have changed"
+        exit 1
+    }
+    Set-Content -Path $SetupPath -Value $content.Replace($old, $new) -NoNewline
+    Write-Host "Patched Windows cxx flags to /permissive- /std:c++20 in $SetupPath"
+}
+
 Write-Host "Building Flash Attention with parameters:"
 Write-Host "  Flash-Attention: $FlashAttnVersion"
 Write-Host "  Python: $PythonVersion"
@@ -336,6 +360,7 @@ if ($FlashAttnVariant -eq "Flash Attention 3") {
 } elseif ($FlashAttnVariant -eq "Flash Attention 2") {
     Write-Host "::group::Checking out flash-attention v$FlashAttnVersion"
     git clone -q https://github.com/Dao-AILab/flash-attention.git flash-attention -b "v$FlashAttnVersion"
+    Patch-Fa2SetupMsvcConformance -SetupPath "flash-attention\setup.py"
     # Remove FA4 (flash_attn/cute) to prevent it from being included in the FA2 wheel
     if (Test-Path "flash-attention\flash_attn\cute") {
         Remove-Item -Recurse -Force "flash-attention\flash_attn\cute"
@@ -418,17 +443,6 @@ $env:FLASH_ATTENTION_FORCE_BUILD = "TRUE"
 $env:NVCC_FLAGS = "-w --disable-warnings"
 $env:CXXFLAGS = "/w"
 $env:CFLAGS = "/w"
-# torch 2.13.0's ArrayRef operator== rework (pytorch/pytorch#185379) is only
-# unambiguous in MSVC conformance mode: pytorch builds itself with
-# /permissive- (cmake/public/utils.cmake) but torch.utils.cpp_extension does
-# not pass it, so extension TUs fail with error C2666 in legacy mode. In
-# conformance mode the same headers then need C++20 (designated initializers
-# in StringUtil.h, bit-field defaults in AutogradState.h), so /std:c++20 is
-# required as well; it overrides the /std:c++17 that flash-attn's setup.py
-# passes because cl.exe appends the _CL_ env var after the command line.
-# _CL_ reaches every cl.exe invocation, including the ones nvcc spawns for
-# host code, so this covers both cl and nvcc compile paths.
-$env:_CL_ = "/permissive- /std:c++20"
 # CUDA 13.2+ ships a CCCL header that emits `#error C1189` when MSVC's
 # traditional preprocessor is in use. Force the standard-conforming
 # preprocessor for both host cl.exe and nvcc-driven cl.exe invocations.

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -421,10 +421,14 @@ $env:CFLAGS = "/w"
 # torch 2.13.0's ArrayRef operator== rework (pytorch/pytorch#185379) is only
 # unambiguous in MSVC conformance mode: pytorch builds itself with
 # /permissive- (cmake/public/utils.cmake) but torch.utils.cpp_extension does
-# not pass it, so extension TUs fail with error C2666 in legacy mode. cl.exe
-# appends the _CL_ env var to every invocation, including the ones nvcc
-# spawns for host code, so this covers both cl and nvcc compile paths.
-$env:_CL_ = "/permissive-"
+# not pass it, so extension TUs fail with error C2666 in legacy mode. In
+# conformance mode the same headers then need C++20 (designated initializers
+# in StringUtil.h, bit-field defaults in AutogradState.h), so /std:c++20 is
+# required as well; it overrides the /std:c++17 that flash-attn's setup.py
+# passes because cl.exe appends the _CL_ env var after the command line.
+# _CL_ reaches every cl.exe invocation, including the ones nvcc spawns for
+# host code, so this covers both cl and nvcc compile paths.
+$env:_CL_ = "/permissive- /std:c++20"
 # CUDA 13.2+ ships a CCCL header that emits `#error C1189` when MSVC's
 # traditional preprocessor is in use. Force the standard-conforming
 # preprocessor for both host cl.exe and nvcc-driven cl.exe invocations.

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -264,34 +264,6 @@ function Apply-CudaToolkitPatch {
     Write-Host "$Description applied successfully"
 }
 
-function Patch-SizesComparisons {
-    param(
-        [Parameter(Mandatory=$true)]
-        [string]$SourcePath
-    )
-
-    # torch 2.13.0 reworked c10::ArrayRef on top of HeaderOnlyArrayRef with
-    # hidden-friend operator== overloads (pytorch/pytorch#170470, #185379),
-    # which MSVC rejects as ambiguous (error C2666) wherever flash-attn
-    # compares x.sizes() with a torch::IntArrayRef (the CHECK_SHAPE macro and
-    # the alibi_slopes checks). Call .equals() explicitly instead; it exists
-    # on all supported torch versions, so patch unconditionally.
-    $pattern = '(\w+)\.sizes\(\) == (torch::IntArrayRef\(\{[^}]*\}\))'
-    $content = Get-Content -Raw $SourcePath
-    $count = [regex]::Matches($content, $pattern).Count
-    if ($count -eq 0) {
-        Write-Error "No sizes() == torch::IntArrayRef comparison found in ${SourcePath}; upstream code may have changed"
-        exit 1
-    }
-    $content = [regex]::Replace($content, $pattern, '$1.sizes().equals($2)')
-    if ($content -match '\.sizes\(\) ==') {
-        Write-Error "Unpatched sizes() == comparison remains in ${SourcePath}; the pattern needs updating"
-        exit 1
-    }
-    Set-Content -Path $SourcePath -Value $content -NoNewline
-    Write-Host "Patched $count sizes() comparison(s) to .equals() in $SourcePath"
-}
-
 Write-Host "Building Flash Attention with parameters:"
 Write-Host "  Flash-Attention: $FlashAttnVersion"
 Write-Host "  Python: $PythonVersion"
@@ -345,7 +317,6 @@ if ($FlashAttnVariant -eq "Flash Attention 3") {
     # Replace upstream setup.py with patched version
     $patchedSetup = Join-Path $PSScriptRoot "patches\fa3\setup_windows.py"
     Copy-Item $patchedSetup "flash-attention\hopper\setup.py" -Force
-    Patch-SizesComparisons -SourcePath "flash-attention\hopper\flash_api.cpp"
     # MSVC cannot pass 128-byte aligned CUDA-generated types by value on CUDA 13.0+.
     if (Test-Cuda13OrNewer -Version $CudaVersion) {
         $cutlassPatch = Join-Path $PSScriptRoot "patches\fa3\cutlass_alignment_fix.patch"
@@ -365,7 +336,6 @@ if ($FlashAttnVariant -eq "Flash Attention 3") {
 } elseif ($FlashAttnVariant -eq "Flash Attention 2") {
     Write-Host "::group::Checking out flash-attention v$FlashAttnVersion"
     git clone -q https://github.com/Dao-AILab/flash-attention.git flash-attention -b "v$FlashAttnVersion"
-    Patch-SizesComparisons -SourcePath "flash-attention\csrc\flash_attn\flash_api.cpp"
     # Remove FA4 (flash_attn/cute) to prevent it from being included in the FA2 wheel
     if (Test-Path "flash-attention\flash_attn\cute") {
         Remove-Item -Recurse -Force "flash-attention\flash_attn\cute"
@@ -448,6 +418,13 @@ $env:FLASH_ATTENTION_FORCE_BUILD = "TRUE"
 $env:NVCC_FLAGS = "-w --disable-warnings"
 $env:CXXFLAGS = "/w"
 $env:CFLAGS = "/w"
+# torch 2.13.0's ArrayRef operator== rework (pytorch/pytorch#185379) is only
+# unambiguous in MSVC conformance mode: pytorch builds itself with
+# /permissive- (cmake/public/utils.cmake) but torch.utils.cpp_extension does
+# not pass it, so extension TUs fail with error C2666 in legacy mode. cl.exe
+# appends the _CL_ env var to every invocation, including the ones nvcc
+# spawns for host code, so this covers both cl and nvcc compile paths.
+$env:_CL_ = "/permissive-"
 # CUDA 13.2+ ships a CCCL header that emits `#error C1189` when MSVC's
 # traditional preprocessor is in use. Force the standard-conforming
 # preprocessor for both host cl.exe and nvcc-driven cl.exe invocations.

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -372,7 +372,14 @@ if ($FlashAttnVariant -eq "Flash Attention 3") {
 } elseif ($FlashAttnVariant -eq "Flash Attention 2") {
     Write-Host "::group::Checking out flash-attention v$FlashAttnVersion"
     git clone -q https://github.com/Dao-AILab/flash-attention.git flash-attention -b "v$FlashAttnVersion"
-    Patch-Fa2SetupMsvcConformance -SetupPath "flash-attention\setup.py"
+    # torch <= 2.12 Windows wheels are all built on the proven c++17
+    # legacy-mode path; only torch >= 2.13 headers need the MSVC
+    # conformance/C++20 treatment, so gate to avoid destabilizing the old
+    # combinations (C++20 changes overload resolution, e.g. rewritten
+    # operator== candidates).
+    if ([Version]$MatrixTorchVersion -ge [Version]"2.13") {
+        Patch-Fa2SetupMsvcConformance -SetupPath "flash-attention\setup.py"
+    }
     # Remove FA4 (flash_attn/cute) to prevent it from being included in the FA2 wheel
     if (Test-Path "flash-attention\flash_attn\cute") {
         Remove-Item -Recurse -Force "flash-attention\flash_attn\cute"

--- a/build_windows.ps1
+++ b/build_windows.ps1
@@ -273,10 +273,10 @@ function Patch-Fa2SetupMsvcConformance {
     # torch 2.13.0 headers fail under MSVC's legacy mode (error C2666 on
     # ArrayRef operator==, pytorch/pytorch#185379) and, once conformance mode
     # is on, additionally require C++20 (C7555/C7582), so switch the
-    # host-only cxx flags to /permissive- + /std:c++20. The "nvcc" flag list
-    # must stay untouched: feeding these flags into nvcc-spawned cl.exe
-    # crashes cudafe++ (0xC0000409). patches/fa3/setup_windows.py carries the
-    # same flags for FA3 directly.
+    # host-only cxx flags to /permissive- + /std:c++20. Passing MSVC flags
+    # via _CL_ instead would reach nvcc-spawned cl.exe and crash cudafe++
+    # (0xC0000409). patches/fa3/setup_windows.py carries the same cxx flags
+    # for FA3 directly.
     $old = '["-O2", "/std:c++17", "/Zc:__cplusplus"]'
     $new = '["-O2", "/permissive-", "/std:c++20", "/Zc:__cplusplus"]'
     $content = Get-Content -Raw $SetupPath
@@ -284,8 +284,20 @@ function Patch-Fa2SetupMsvcConformance {
         Write-Error "Windows cxx flag list not found in ${SetupPath}; upstream setup.py may have changed"
         exit 1
     }
-    Set-Content -Path $SetupPath -Value $content.Replace($old, $new) -NoNewline
-    Write-Host "Patched Windows cxx flags to /permissive- /std:c++20 in $SetupPath"
+    $content = $content.Replace($old, $new)
+    # nvcc's EDG front end emulates the MSVC host and rejects the same C++20
+    # constructs in c++17 mode ("data member initializer is not allowed" in
+    # AutogradState.h), so device compilation needs c++20 as well; torch
+    # 2.13's own JIT path passes -std=c++20 to nvcc on Windows. FA3's nvcc
+    # std stays c++17 (its .cu files compiled fine for hours in v0.9.51).
+    $nvccPattern = '(nvcc_flags = \[\s*"-O3",\s*)"-std=c\+\+17",'
+    if ($content -notmatch $nvccPattern) {
+        Write-Error "nvcc_flags std entry not found in ${SetupPath}; upstream setup.py may have changed"
+        exit 1
+    }
+    $content = [regex]::Replace($content, $nvccPattern, '$1"-std=c++20",')
+    Set-Content -Path $SetupPath -Value $content -NoNewline
+    Write-Host "Patched Windows cxx flags to /permissive- /std:c++20 and nvcc std to c++20 in $SetupPath"
 }
 
 Write-Host "Building Flash Attention with parameters:"

--- a/patches/fa3/setup_windows.py
+++ b/patches/fa3/setup_windows.py
@@ -759,7 +759,17 @@ if not SKIP_CUDA_BUILD:
             name=f"{PACKAGE_NAME}._C",
             sources=sources,
             extra_compile_args={
-                "cxx": ["-O3", "-std=c++17", "-DPy_LIMITED_API=0x03090000"]
+                # /permissive- + /std:c++20: torch 2.13.0 headers fail under
+                # MSVC's legacy mode (error C2666 on ArrayRef operator==) and
+                # need C++20 in conformance mode; cl.exe ignores the unix-style
+                # flags. Host-only: nvcc reads the "nvcc" list instead.
+                "cxx": [
+                    "-O3",
+                    "-std=c++17",
+                    "/permissive-",
+                    "/std:c++20",
+                    "-DPy_LIMITED_API=0x03090000",
+                ]
                 + stable_args
                 + feature_args,
                 "nvcc": nvcc_threads_args() + nvcc_flags + cc_flag + feature_args,

--- a/patches/fa3/setup_windows.py
+++ b/patches/fa3/setup_windows.py
@@ -759,17 +759,18 @@ if not SKIP_CUDA_BUILD:
             name=f"{PACKAGE_NAME}._C",
             sources=sources,
             extra_compile_args={
-                # /permissive- + /std:c++20: torch 2.13.0 headers fail under
+                # /permissive- + /std:c++20: torch >= 2.13 headers fail under
                 # MSVC's legacy mode (error C2666 on ArrayRef operator==) and
                 # need C++20 in conformance mode; cl.exe ignores the unix-style
-                # flags. Host-only: nvcc reads the "nvcc" list instead.
-                "cxx": [
-                    "-O3",
-                    "-std=c++17",
-                    "/permissive-",
-                    "/std:c++20",
-                    "-DPy_LIMITED_API=0x03090000",
-                ]
+                # flags. Host-only: nvcc reads the "nvcc" list instead. Gated
+                # so proven torch <= 2.12 builds keep their c++17 legacy path.
+                "cxx": ["-O3", "-std=c++17"]
+                + (
+                    ["/permissive-", "/std:c++20"]
+                    if torch_version.release >= (2, 13)
+                    else []
+                )
+                + ["-DPy_LIMITED_API=0x03090000"]
                 + stable_args
                 + feature_args,
                 "nvcc": nvcc_threads_args() + nvcc_flags + cc_flag + feature_args,


### PR DESCRIPTION
## Overview and Background

Windows builds of flash-attn 2.8.3 / FA3 against torch 2.13.0 fail to compile (all 18 jobs of v0.9.50/v0.9.51). Root cause, established over four test iterations: **torch >= 2.12 is built as C++20 with MSVC conformance mode (`/permissive-`, `cmake/public/utils.cmake`), but `torch.utils.cpp_extension` still compiles extensions in MSVC legacy mode with c++17**. torch 2.13.0's headers are only valid under the conformant C++20 combination:

1. Legacy mode resolves the reworked `c10::ArrayRef` `operator==` (pytorch/pytorch#170470, #185379) as ambiguous → `error C2666` (in flash-attn's `CHECK_SHAPE` and in torch's own `nn/functional/*.h`)
2. Conformance mode then requires C++20 for designated initializers / bit-field default member initializers in `c10` headers → C7555/C7582
3. nvcc's EDG front end emulates the MSVC host and rejects the same constructs under `-std=c++17`

This supersedes the source-patching approach: #148 (merged; reverted here) rewrote flash-attn's comparisons but could not cover torch's own headers, and #149 (closed) swept the venv headers. Compiling with the same flags torch itself uses fixes all of it without touching any sources.

## Changes

- `build_windows.ps1`:
  - Remove `Patch-SizesComparisons` (the #148 source rewriting)
  - Add `Patch-Fa2SetupMsvcConformance`: rewrites FA2 `setup.py`'s Windows flag list to `["-O2", "/permissive-", "/std:c++20", "/Zc:__cplusplus"]` and bumps `nvcc_flags` from `-std=c++17` to `-std=c++20` (torch 2.13's JIT path already passes `-std=c++20` to nvcc on Windows), with fail-fast checks if upstream changes the lists
  - **Gated to torch >= 2.13** (`$MatrixTorchVersion`): torch <= 2.12 wheels are all proven on the c++17 legacy path, and C++20 changes overload resolution (rewritten `operator==` candidates), so old combinations stay untouched
- `patches/fa3/setup_windows.py`: add `/permissive-` + `/std:c++20` to the cxx flags under the same `torch_version.release >= (2, 13)` gate. FA3's nvcc std stays c++17 (its `.cu` files compiled for 5.5 h in the v0.9.51 run; only host-compiled `flash_api*.cpp` needs the flags)
- The flags flow through `extra_compile_args` only — injecting them via the `_CL_` env var instead reaches the cl.exe that nvcc spawns internally and crashes cudafe++ (0xC0000409; iteration 2 result)
- Self-hosted and AWS CodeBuild Windows builds also run `build_windows.ps1`, so the gate covers every Windows path

## Test Instructions

Verified with `test-build.yml` → `windows-github-hosted` (2.8.3, py3.12, torch 2.13.0, cu12.6):

- Baseline (v0.9.50/51 and iterations 1-3): every run died 2-4 min into "Build wheels" (~12 min job time) with C2666 → C7555/C7582 → EDG errors as each layer was peeled
- Run 30187972549 (flags, pre-gate) and run 30188776027 (final gated commit): both passed the entire compile-error window (30+/15+ min alive, kernels compiling) and were then cancelled to save runner time
- Gate logic unit-tested in both languages (PowerShell `[Version]` compare, Python `torch_version.release >= (2, 13)` incl. `+cu126`/`.dev` suffixes); `build_windows.ps1` parse-checked, `setup_windows.py` ast-checked
- Full end-to-end validation happens on the next `v*` tag: the matrix on main (#147) is already scoped to the 18 missing Windows wheels

Note: builds are expected to hit the 330-min cap on cold attempts; resume with `gh run rerun <run_id> --failed` per the #144/#145 flow.
