### PR TITLE
feat: support PyTorch 2.14.0 (C++20 on Linux for torch >= 2.14)

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+# torch >= 2.14 headers (ATen/ATen.h, torch/all.h) `#error` when
+# __cplusplus < 202002L on non-MSVC compilers, but FA2 pins -std=c++17 for
+# both cxx and nvcc and its .cu files include c10/ATen headers, so both must
+# move to C++20. Gated like build_windows.ps1's Patch-Fa2SetupMsvcConformance
+# so the proven torch <= 2.13 builds keep their c++17 path.
+fa2_needs_cxx20() {
+  awk -v v="$1" 'BEGIN { split(v, a, "."); exit !((a[1] > 2) || (a[1] == 2 && a[2] >= 14)) }'
+}
+
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 
 # Parameters with defaults
@@ -65,6 +74,14 @@ if [[ "$FLASH_ATTN_VARIANT" == "Flash Attention 3" ]]; then
 elif [[ "${FLASH_ATTN_VARIANT}" == "Flash Attention 2" ]]; then
   echo "Checking out flash-attention v${FLASH_ATTN_VERSION}..."
   git clone https://github.com/Dao-AILab/flash-attention.git flash-attention -b "v$FLASH_ATTN_VERSION"
+  if fa2_needs_cxx20 "$MATRIX_TORCH_VERSION"; then
+    if [ "$(grep -c -- '-std=c++17' flash-attention/setup.py)" -eq 0 ]; then
+      echo "-std=c++17 not found in flash-attention/setup.py; upstream setup.py may have changed"
+      exit 1
+    fi
+    sed -i 's/-std=c++17/-std=c++20/g' flash-attention/setup.py
+    echo "Patched flash-attention/setup.py cxx/nvcc std to c++20 for torch $MATRIX_TORCH_VERSION"
+  fi
   # Remove FA4 (flash_attn/cute) to prevent it from being included in the FA2 wheel
   rm -rf flash-attention/flash_attn/cute
   BUILD_ROOT=flash-attention/build

--- a/create_matrix.py
+++ b/create_matrix.py
@@ -30,6 +30,7 @@ LINUX_MATRIX = {
         # "2.11.0",
         # "2.12.1",
         # "2.13.0",
+        # "2.14.0",
     ],
     "cuda-version": [
         # "12.4",
@@ -57,6 +58,7 @@ LINUX_ARM64_MATRIX = {
     "torch-version": [
         # "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": [
         "12.6",
@@ -91,6 +93,7 @@ LINUX_SELF_HOSTED_MATRIX = {
         # "2.11.0",
         # "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": [
         # "12.4",
@@ -126,6 +129,7 @@ LINUX_ARM64_SELF_HOSTED_MATRIX = {
         "2.11.0",
         "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": [
         # "12.4",
@@ -163,6 +167,7 @@ LINUX_NO_CONTAINER_MATRIX = {
         "2.11.0",
         "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": [
         # "12.4",
@@ -200,6 +205,7 @@ LINUX_ARM64_NO_CONTAINER_MATRIX = {
         "2.11.0",
         "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": [
         # "12.4",
@@ -233,6 +239,7 @@ WINDOWS_MATRIX = {
         # "2.11.0",
         # "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": [
         # "12.4",
@@ -269,6 +276,7 @@ WINDOWS_CODEBUILD_MATRIX = {
         # "2.11.0",
         # "2.12.1",
         # "2.13.0",
+        # "2.14.0",
     ],
     "cuda-version": [
         "12.8",
@@ -288,8 +296,8 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         "3.12",
         "3.13",
         "3.14",
-        # "3.13t",  # torch 2.12.1/2.13.0 no longer publish cp313t wheels
-        # "3.14t",  # Excluded: torch 2.12.x/2.13.0's setuptools/cpp_extension cannot
+        # "3.13t",  # torch 2.12.1/2.13.0/2.14.0 no longer publish cp313t wheels
+        # "3.14t",  # Excluded: torch 2.12.x/2.13.0/2.14.0's setuptools/cpp_extension cannot
         # resolve the free-threaded import library on Windows
         # (LNK1104: python314.lib vs python314t.lib). Re-enable once PyTorch
         # / setuptools handle this for free-threaded CPython on Windows.
@@ -304,6 +312,7 @@ WINDOWS_SELF_HOSTED_MATRIX = {
         # "2.11.0",
         "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": [
         # "12.4",

--- a/patches/fa3/setup_linux.py
+++ b/patches/fa3/setup_linux.py
@@ -618,6 +618,12 @@ if not SKIP_CUDA_BUILD:
     else:
         flash_api_source = "flash_api.cpp"
 
+    # torch >= 2.14 headers (ATen/ATen.h, torch/all.h) #error on non-MSVC
+    # compilers when __cplusplus < 202002L. flash_api(_stable).cpp includes
+    # those headers, so cxx must move to C++20; the .cu files under hopper/
+    # never include torch/c10/ATen headers, so nvcc keeps C++17.
+    cxx_std = "-std=c++20" if torch_version.release >= (2, 14) else "-std=c++17"
+
     sources = (
         [flash_api_source]
         + (sources_fwd_sm80 if not DISABLE_SM8x else [])
@@ -653,7 +659,7 @@ if not SKIP_CUDA_BUILD:
             name=f"{PACKAGE_NAME}._C",
             sources=sources,
             extra_compile_args={
-                "cxx": ["-O3", "-std=c++17", "-DPy_LIMITED_API=0x03090000"]
+                "cxx": ["-O3", cxx_std, "-DPy_LIMITED_API=0x03090000"]
                 + stable_args
                 + feature_args,
                 "nvcc": nvcc_threads_args() + nvcc_flags + cc_flag + feature_args,

--- a/scripts/coverage_matrix.py
+++ b/scripts/coverage_matrix.py
@@ -23,6 +23,7 @@ TORCH_FULL_VERSIONS = [
     "2.11.0",
     "2.12.1",
     "2.13.0",
+    "2.14.0",
 ]
 TORCH_SUPPORT_CUDA_VERSIONS = {
     "2.0": ("11.7", "11.8"),
@@ -39,6 +40,7 @@ TORCH_SUPPORT_CUDA_VERSIONS = {
     "2.11": ("12.6", "12.8", "13.0"),
     "2.12": ("12.6", "13.0", "13.2"),
     "2.13": ("12.6", "13.0", "13.2"),
+    "2.14": ("12.6", "13.0", "13.2"),
 }
 # torch_version: minimum and maximum supported Python versions
 TORCH_SUPPORT_PYTHON_VERSIONS = {
@@ -56,6 +58,7 @@ TORCH_SUPPORT_PYTHON_VERSIONS = {
     "2.11": ("3.10", "3.14"),
     "2.12": ("3.10", "3.14"),
     "2.13": ("3.10", "3.14"),
+    "2.14": ("3.10", "3.14"),
 }
 TORCH_EXPERIMENTAL_FREE_THREADED_PYTHON_VERSIONS = {
     "2.6": ("3.13t",),
@@ -66,6 +69,7 @@ TORCH_EXPERIMENTAL_FREE_THREADED_PYTHON_VERSIONS = {
     "2.11": ("3.13t", "3.14t"),
     "2.12": ("3.14t",),
     "2.13": ("3.14t",),
+    "2.14": ("3.14t",),
 }
 
 # FA3 is distributed as a single ABI3 wheel per (torch, cuda) combination, so
@@ -183,6 +187,7 @@ LINUX_MATRIX = {
         "2.11.0",
         "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": ["12.4", "12.6", "12.8", "12.9", "13.0", "13.2"],
 }
@@ -196,6 +201,7 @@ LINUX_ARM64_MATRIX = {
         "2.11.0",
         "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": ["12.6", "12.8", "12.9", "13.0", "13.2"],
 }
@@ -203,7 +209,7 @@ LINUX_ARM64_MATRIX = {
 # Windows excludes "3.14t" because torch 2.12.x's setuptools/cpp_extension cannot
 # resolve the free-threaded import library on Windows
 # (LNK1104: python314.lib vs python314t.lib). 3.13t is pruned for torch
-# 2.12.1/2.13.0 by TORCH_EXPERIMENTAL_FREE_THREADED_PYTHON_VERSIONS because
+# 2.12.1/2.13.0/2.14.0 by TORCH_EXPERIMENTAL_FREE_THREADED_PYTHON_VERSIONS because
 # those versions do not publish cp313t wheels.
 WINDOWS_PYTHON_VERSIONS = [*PYTHON_VERSIONS, "3.13t"]
 
@@ -216,6 +222,7 @@ WINDOWS_MATRIX = {
         "2.11.0",
         "2.12.1",
         "2.13.0",
+        "2.14.0",
     ],
     "cuda-version": ["12.6", "12.8", "13.0", "13.2"],
 }


### PR DESCRIPTION
## Overview and Background

This PR makes the build pipeline produce flash-attn 2.6.3 / 2.7.4 / 2.8.3 and FA3 wheels for PyTorch 2.14.0 on Linux x86_64, Linux ARM64, and Windows, and makes the coverage tooling count torch 2.14.0 as an expected version.

PyTorch 2.14.0 (released 2026-09-02) publishes CUDA wheels for cu126 / cu130 / cu132 and Python 3.10–3.14 plus 3.14t (no cp313t), the same shape as 2.12 / 2.13. The matrix definitions in this repository stopped at 2.13.0, so no 2.14.0 wheel could be built or counted as missing.

On top of the matrix gap, the Linux build path breaks outright on torch 2.14: `ATen/ATen.h` and `torch/all.h` now `#error` on non-MSVC compilers when `__cplusplus < 202002L` (2.13 required only C++17). Every flash-attn `setup.py` pins `-std=c++17` explicitly, and torch's `cpp_extension` never overrides an explicit standard, so `build_linux.sh` failed at `flash_api.cpp` for both FA2 and FA3. FA2's `.cu` files also include c10 / ATen headers, so the device side needs C++20 as well. Windows is unaffected: MSVC is exempt from the guard, and #150 already switched the Windows host flags to `/permissive- /std:c++20` for torch >= 2.13, which covers 2.14.

## Related Issues

Closes #153

## Implementation Approach

- Add torch 2.14.0 to `scripts/coverage_matrix.py` (full-version list, CUDA / Python / free-threaded support tables, and the three platform coverage matrices) and to every platform matrix in `create_matrix.py`. `EXCLUDE` and `get_torch_cuda_version.py` derive everything else from those tables, so no logic changes are needed.
- Move the Linux build to C++20 only where torch requires it, gated on torch >= 2.14 so the proven torch <= 2.13 combinations keep their c++17 path. This mirrors the gate already used for Windows in #150.
  - FA2: `build_linux.sh` rewrites every `-std=c++17` in the cloned upstream `setup.py` to `-std=c++20` (cxx and nvcc). The rewrite is a plain global substitution because the three supported versions lay out their flag lists differently. If no `-std=c++17` is found the script prints a message and exits non-zero, so an upstream change never silently builds with the wrong standard.
  - FA3: `patches/fa3/setup_linux.py` switches only the `cxx` standard via a one-line `cxx_std` variable. The hopper `.cu` sources never include torch / c10 / ATen headers, so nvcc keeps the proven `-std=c++17`.
- Rejected: appending `-std=c++20` through `NVCC_APPEND_FLAGS` / `CXXFLAGS`. Both flags would reach the compiler alongside flash-attn's `-std=c++17`, and which one wins would depend on flag order.
- Out of scope, by decision: Python 3.15 / 3.15t (torch 2.14.0 ships cp315 wheels, but CPython 3.15.0 final is scheduled for 2026-10-01; uv would build against rc2 today), and any sm120 work (FA2 2.7.4 / 2.8.3 already emit `sm_120` for cu130 / cu132; FA2 2.6.3 and FA3 have no sm120 path upstream).

## Changes

- **Coverage definitions**: torch 2.14.0 added to `TORCH_FULL_VERSIONS`, `TORCH_SUPPORT_CUDA_VERSIONS` (12.6 / 13.0 / 13.2), `TORCH_SUPPORT_PYTHON_VERSIONS` (3.10–3.14), `TORCH_EXPERIMENTAL_FREE_THREADED_PYTHON_VERSIONS` (3.14t), and the Linux / ARM64 / Windows coverage matrices. The Windows 3.13t exclusion comment now lists 2.14.0.
- **Build matrix**: every one of the nine platform matrices gets a `"2.14.0"` entry in the same enabled / commented state as its `"2.13.0"` entry. The Windows 3.13t / 3.14t exclusion comments mention 2.14.0.
- **Linux FA2 build**: new `fa2_needs_cxx20` gate (numeric major.minor comparison via awk, so `2.9` is not mistaken for `> 2.14`) and the guarded `-std=c++17` → `-std=c++20` rewrite right after the FA2 clone.
- **Linux FA3 build**: `cxx_std` selects `-std=c++20` for torch >= 2.14 and `-std=c++17` otherwise; nvcc flags are untouched.

## Impact

- New wheels named `flash_attn-<ver>+cu{126,130,132}torch2.14-...` become buildable and expected by `check_missing_packages` / README coverage generation.
- No behavior change for torch <= 2.13 on Linux: the gate keeps both FA2 and FA3 on their current c++17 flags (confirmed by the 2.13.0 regression build below).
- Windows build scripts are unchanged.
- Publishing the actual torch 2.14.0 wheels (tag release and matrix scoping) is a follow-up release operation, as with 2.13.0.
- Known pre-existing issue, unrelated to this change: on the Linux hosted runner `auditwheel repair` fails with `patchelf 0.14.3 found. auditwheel repair requires patchelf >= 0.14.5`, so the manylinux wheel test / upload step is effectively a no-op. The torch 2.13.0 regression run shows the same failure.

## Validation Results

`test-build.yml` was run on this branch (commit 7202e2c, identical code to the rebased HEAD) with `use-build-cache=true` for all five combinations:

| platform | flash-attn | torch | CUDA | result |
|---|---|---|---|---|
| linux-x64-github-hosted | 2.8.3 | 2.14.0 | 13.0 | success, [run 34036375375](https://github.com/mjun0812/flash-attention-prebuild-wheels/actions/runs/34036375375) |
| linux-x64-github-hosted | fa3:e2743ab | 2.14.0 | 13.0 | success, [run 34036377177](https://github.com/mjun0812/flash-attention-prebuild-wheels/actions/runs/34036377177) |
| linux-x64-github-hosted | 2.8.3 | 2.13.0 (regression) | 13.0 | success, [run 34036378794](https://github.com/mjun0812/flash-attention-prebuild-wheels/actions/runs/34036378794) |
| windows-github-hosted | 2.8.3 | 2.14.0 | 13.0 | success on attempt 2 after the 330-minute cap saved the cache, [run 34036380615](https://github.com/mjun0812/flash-attention-prebuild-wheels/actions/runs/34036380615) |
| windows-github-hosted | fa3:e2743ab | 2.14.0 | 13.0 | success on attempt 3 (two capped attempts, cache restored each time), [run 34036382158](https://github.com/mjun0812/flash-attention-prebuild-wheels/actions/runs/34036382158) |

In the logs: the torch 2.14.0 FA2 run prints `Patched flash-attention/setup.py cxx/nvcc std to c++20 for torch 2.14` and all 73 compile commands use `-std=c++20`; the torch 2.13.0 run prints nothing and all 73 use `-std=c++17`; the FA3 run compiles `flash_api_stable.cpp` with `-std=c++20` and all 292 `.cu` files with `-std=c++17`. Each run's `import flash_attn` / `import flash_attn_3` test step passed (`2.8.3`, `3.0.0+cu130torch2.14gite2743ab`).

Local checks (all pass):

```bash
uv run --python 3.14 python -c "from scripts.coverage_matrix import *; assert TORCH_SUPPORT_CUDA_VERSIONS['2.14'] == ('12.6', '13.0', '13.2'); assert TORCH_EXPERIMENTAL_FREE_THREADED_PYTHON_VERSIONS['2.14'] == ('3.14t',)"
uv run --python 3.14 python -c "from scripts.coverage_matrix import EXCLUDE as E; assert {'torch-version': '2.14.0', 'cuda-version': '12.8'} in E; assert {'torch-version': '2.14.0', 'python-version': '3.14t'} not in E"
uv run --python 3.14 --script create_matrix.py | python3 -m json.tool > /dev/null
# the sed used by build_linux.sh replaces all four -std=c++17 occurrences in upstream v2.6.3 / v2.7.4 / v2.8.3 setup.py
d=$(mktemp -d) && git clone -q -b v2.8.3 --depth 1 https://github.com/Dao-AILab/flash-attention.git "$d" && sed -i.bak 's/-std=c++17/-std=c++20/g' "$d/setup.py" && [ "$(grep -c -- '-std=c++17' "$d/setup.py")" -eq 0 ]
bash -c 'eval "$(sed -n "/^fa2_needs_cxx20()/,/^}/p" build_linux.sh)"; ! fa2_needs_cxx20 2.9 && ! fa2_needs_cxx20 2.13 && fa2_needs_cxx20 2.14'
```

`ruff format --check` passes for the three changed Python files, and `ruff check` reports the same rule set as on `main` for each of them (the repository-wide `ruff check` already fails on `main` with pre-existing findings and is unchanged here).
